### PR TITLE
Sandbox templates + ready-on-resolve create

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -10,9 +10,20 @@
     "railway"
   ],
   "usedClassMembers": [
-    "exec",
+    "build",
+    "createdAt",
     "delete",
-    "toJSON"
+    "destroy",
+    "exec",
+    "idleTimeoutMinutes",
+    "refresh",
+    "region",
+    "run",
+    "status",
+    "toJSON",
+    "withEnv",
+    "withPackages",
+    "workdir"
   ],
   "ignorePatterns": [
     "src/generated/graphql.ts"

--- a/README.md
+++ b/README.md
@@ -97,26 +97,25 @@ const base = Sandbox.template()
   .withPackages("ffmpeg")
   .workdir("/app");
 
-// Same call whether the template is cold (builds, then forks) or warm (just forks).
 const sandbox = await Sandbox.create(base);
 await sandbox.exec("ffmpeg -version");
 ```
 
 A `SandboxTemplate` is a **fluent, immutable recipe** — every step returns a new
-template, so a base can branch into variants without mutation surprises. It is a pure
-value and does no network until it is built.
+template, so a base can branch into variants without mutation surprises. It is sent to
+Railway only when you build it or create a sandbox from it.
 
 - `.run(command)` — a raw build step.
 - `.withPackages(...names)` — install Debian packages.
 - `.withEnv({ KEY: "value" })` — set environment variables for later steps.
 - `.workdir(dir)` — set the working directory for later steps.
-- `.build(options?)` — build the template ahead of time (idempotent; cheap when warm),
-  so later `create` calls just fork. `Sandbox.create(template)` builds for you, so this
-  is only needed to pre-warm.
+- `.build(options?)` — build the template ahead of time, so later `create` calls can
+  fork from the cached build. `Sandbox.create(template)` builds for you, so this is
+  only needed to pre-warm.
 
 Obtain a template with `Sandbox.template()`; the constructor is private. Building throws
 `SandboxTemplateBuildError` on a failed build and `SandboxTimeoutError` if readiness
-exceeds the internal ceiling.
+exceeds the 5-minute timeout.
 
 ## Configuration
 
@@ -159,7 +158,8 @@ All errors extend `RailwayError`:
 - `SandboxTemplateBuildError` — a template build finished `FAILED`. Carries
   `.templateId` and `.environmentId`.
 - `SandboxTimeoutError` — a readiness wait (template → `READY` or sandbox → `RUNNING`)
-  exceeded the time ceiling. Carries `.resource`, `.id`, `.lastStatus`, and `.timeoutMs`.
+  exceeded the 5-minute timeout. Carries `.resource`, `.id`, `.lastStatus`, and
+  `.timeoutMs`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ await sandbox.destroy();
 private. A sandbox always comes from somewhere:
 
 - `Sandbox.create(options?)` — provision a new sandbox.
+- `Sandbox.create(template, options?)` — provision from a reusable template (see [Templates](#templates)).
 - `Sandbox.connect(id, options?)` — reattach to an existing sandbox by id.
 - `Sandbox.list(options?)` — list sandboxes in the environment.
+
+`create` resolves only once the sandbox is `RUNNING`, so the sandbox you receive is
+ready to `exec` against — there is no readiness wait to manage yourself.
 
 ## Running commands
 
@@ -79,6 +83,41 @@ await sandbox.exec("pytest");
 
 `sandbox.destroy()` is always available for explicit teardown.
 
+## Templates
+
+A template is a reusable base: an ordered list of build steps (system packages, env,
+a working directory, raw commands) that Railway builds once, content-addresses, and
+caches. Creating a sandbox from a template forks that cached build instead of starting
+from scratch.
+
+```ts
+import { Sandbox } from "railway";
+
+const base = Sandbox.template()
+  .withPackages("ffmpeg")
+  .workdir("/app");
+
+// Same call whether the template is cold (builds, then forks) or warm (just forks).
+const sandbox = await Sandbox.create(base);
+await sandbox.exec("ffmpeg -version");
+```
+
+A `SandboxTemplate` is a **fluent, immutable recipe** — every step returns a new
+template, so a base can branch into variants without mutation surprises. It is a pure
+value and does no network until it is built.
+
+- `.run(command)` — a raw build step.
+- `.withPackages(...names)` — install Debian packages.
+- `.withEnv({ KEY: "value" })` — set environment variables for later steps.
+- `.workdir(dir)` — set the working directory for later steps.
+- `.build(options?)` — build the template ahead of time (idempotent; cheap when warm),
+  so later `create` calls just fork. `Sandbox.create(template)` builds for you, so this
+  is only needed to pre-warm.
+
+Obtain a template with `Sandbox.template()`; the constructor is private. Building throws
+`SandboxTemplateBuildError` on a failed build and `SandboxTimeoutError` if readiness
+exceeds the internal ceiling.
+
 ## Configuration
 
 `token`, `environmentId`, and `endpoint` each resolve in order: an explicit option,
@@ -114,6 +153,12 @@ All errors extend `RailwayError`:
   `.errors`, and `.responseBody`.
 - `SandboxNotFoundError` — `connect` or `refresh` could not find the sandbox. Carries
   `.id` and `.environmentId`.
+- `SandboxFailedError` — a sandbox reached a terminal state (`FAILED`/`DESTROYED`)
+  before becoming `RUNNING` during `create`. Carries `.id` and `.status`.
+- `SandboxTemplateBuildError` — a template build finished `FAILED`. Carries
+  `.templateId` and `.environmentId`.
+- `SandboxTimeoutError` — a readiness wait (template → `READY` or sandbox → `RUNNING`)
+  exceeded the time ceiling. Carries `.resource`, `.id`, `.lastStatus`, and `.timeoutMs`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ All errors extend `RailwayError`:
   `.errors`, and `.responseBody`.
 - `SandboxNotFoundError` — `connect` or `refresh` could not find the sandbox. Carries
   `.id` and `.environmentId`.
-- `SandboxFailedError` — a sandbox reached a terminal state (`FAILED`/`DESTROYED`)
-  before becoming `RUNNING` during `create`. Carries `.id` and `.status`.
+- `SandboxFailedError` — a sandbox reached a terminal state (`FAILED`, `DESTROYING`,
+  or `DESTROYED`) before becoming `RUNNING` during `create`. Carries `.id` and
+  `.status`.
 - `SandboxTemplateBuildError` — a template build finished `FAILED`. Carries
   `.templateId` and `.environmentId`.
 - `SandboxTimeoutError` — a readiness wait (template → `READY` or sandbox → `RUNNING`)

--- a/docs/sandbox-sdk-vision.md
+++ b/docs/sandbox-sdk-vision.md
@@ -192,8 +192,8 @@ environment (a runtime, system packages, your code) and you want to stamp sandbo
 from it instantly.
 
 A `SandboxTemplate` is a **fluent, immutable recipe**. Every step returns a new
-template, so a base can branch into variants without mutation surprises. It is a pure
-value — no network happens until `build()` or `Sandbox.create(template)`.
+template, so a base can branch into variants without mutation surprises. It is sent to
+Railway only when you build it or create a sandbox from it.
 
 ```ts
 const base = Sandbox.template()
@@ -202,13 +202,13 @@ const base = Sandbox.template()
 
 const withUv = base.run("pip install uv"); // branches; `base` is untouched
 
-const sandbox = await Sandbox.create(base); // builds if cold, forks if warm
+const sandbox = await Sandbox.create(base);
 ```
 
-Live today: `.run("…")` (the raw escape hatch), `.withPackages(…)`, `.withEnv(…)`,
-`.workdir(…)`, and `template.build()`. Builds run server-side on the default base
-image, content-addressed and cached — a warm template just forks. Reserved for later:
-custom base images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
+Available today: `.run("…")` (the raw escape hatch), `.withPackages(…)`,
+`.withEnv(…)`, `.workdir(…)`, and `template.build()`. Builds run server-side on the
+default base image, content-addressed and cached. Reserved for later: custom base
+images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
 `withPython`, `copy`), and `.toDockerfile()` transparency.
 
 > The types are named `SandboxTemplate` / `SandboxBase` — never a bare `Template` —
@@ -223,10 +223,10 @@ One verb covers every way to start a sandbox. `create()` with no source is the b
 box; `create(source)` starts from a reusable base.
 
 ```ts
-const fromTemplate = await Sandbox.create(base); // live today: a SandboxTemplate value
+const fromTemplate = await Sandbox.create(base);
 
 // FUTURE
-const forked = await sandbox.fork(); // == Sandbox.create(sandbox)
+const forked = await sandbox.fork(); // equivalent to Sandbox.create(sandbox)
 const fromImage = await Sandbox.create({ image: "ubuntu:24.04" });
 ```
 
@@ -275,7 +275,7 @@ All SDK errors extend `RailwayError`:
 | `SandboxNotFoundError` | `connect` / `refresh` could not find the sandbox in the environment. Carries `.id`, `.environmentId`. |
 | `SandboxFailedError` | A sandbox reached a terminal state (`FAILED`, `DESTROYING`, or `DESTROYED`) before becoming `RUNNING` during `create`. Carries `.id`, `.status`. |
 | `SandboxTemplateBuildError` | A template build finished `FAILED`. Carries `.templateId`, `.environmentId`. |
-| `SandboxTimeoutError` | A readiness wait (template → `READY` or sandbox → `RUNNING`) exceeded the 5-minute ceiling. Carries `.resource`, `.id`, `.lastStatus`, `.timeoutMs`. |
+| `SandboxTimeoutError` | A readiness wait (template → `READY` or sandbox → `RUNNING`) exceeded the 5-minute timeout. Carries `.resource`, `.id`, `.lastStatus`, `.timeoutMs`. |
 | `SandboxFileNotFoundError` / `SandboxFileTooLargeError` _(future)_ | File operations. |
 
 ---
@@ -350,8 +350,6 @@ class Sandbox {
   toJSON(): SandboxInfo;
 }
 
-// Fluent, immutable recipe — every builder returns a new template. Obtain one
-// via `Sandbox.template()`; it is a pure value and does no network until built.
 interface SandboxTemplate {
   run(command: string): SandboxTemplate;
   withPackages(...packages: string[]): SandboxTemplate;

--- a/docs/sandbox-sdk-vision.md
+++ b/docs/sandbox-sdk-vision.md
@@ -223,17 +223,18 @@ One verb covers every way to start a sandbox. `create()` with no source is the b
 box; `create(source)` starts from a reusable base.
 
 ```ts
+const fromTemplate = await Sandbox.create(base); // live today: a SandboxTemplate value
+
 // FUTURE
-const fromTemplate = await Sandbox.create(base);                 // a SandboxTemplate value
-const forked = await sandbox.fork();                             // == Sandbox.create(sandbox)
-const fromImage = await Sandbox.create({ image: "ubuntu:24.04" }); // an explicit registry image
+const forked = await sandbox.fork(); // == Sandbox.create(sandbox)
+const fromImage = await Sandbox.create({ image: "ubuntu:24.04" });
 ```
 
-`create` accepts a `SandboxTemplate` or a running `Sandbox` as a **value**, or an
-explicit `{ image }` object. There is no bare-string source, so there is never any
-guessing between "a base name" and "an image tag" — the source's type says what it is.
-`sandbox.fork()` is sugar for `Sandbox.create(this)`, giving the live-environment fork
-its own obvious home.
+Today, `create` accepts a `SandboxTemplate`. Future sources are a running `Sandbox`
+value or an explicit `{ image }` object. There is no bare-string source, so there is
+never any guessing between "a base name" and "an image tag" — the source's type says
+what it is. `sandbox.fork()` is sugar for `Sandbox.create(this)`, giving the
+live-environment fork its own obvious home.
 
 ---
 
@@ -272,7 +273,7 @@ All SDK errors extend `RailwayError`:
 | `RailwayAuthError` | A required credential (`token` / `environmentId`) could not be resolved. Carries `.variable`. |
 | `RailwayGraphQLError` | The Railway API returned an error. Carries `.status`, `.errors`, `.responseBody`. |
 | `SandboxNotFoundError` | `connect` / `refresh` could not find the sandbox in the environment. Carries `.id`, `.environmentId`. |
-| `SandboxFailedError` | A sandbox reached a terminal state (`FAILED`/`DESTROYED`) before becoming `RUNNING` during `create`. Carries `.id`, `.status`. |
+| `SandboxFailedError` | A sandbox reached a terminal state (`FAILED`, `DESTROYING`, or `DESTROYED`) before becoming `RUNNING` during `create`. Carries `.id`, `.status`. |
 | `SandboxTemplateBuildError` | A template build finished `FAILED`. Carries `.templateId`, `.environmentId`. |
 | `SandboxTimeoutError` | A readiness wait (template → `READY` or sandbox → `RUNNING`) exceeded the 5-minute ceiling. Carries `.resource`, `.id`, `.lastStatus`, `.timeoutMs`. |
 | `SandboxFileNotFoundError` / `SandboxFileTooLargeError` _(future)_ | File operations. |
@@ -321,8 +322,6 @@ import {
   type SandboxInfo,
   type SandboxStatus,
   type SandboxTemplate,
-  type SandboxTemplateInfo,
-  type SandboxTemplateStatus,
   type TemplateBuildOptions,
   type RailwayClientConfig,
   type RailwayGraphQLErrorItem,

--- a/docs/sandbox-sdk-vision.md
+++ b/docs/sandbox-sdk-vision.md
@@ -185,27 +185,31 @@ Planned surface: `read` / `readText` / `write` / `list` / `info` / `exists` /
 
 ---
 
-## 9. Templates: reusable bases _(future)_
+## 9. Templates: reusable bases
 
 The centerpiece of the vision. You rarely want a blank box — you want _your_
 environment (a runtime, system packages, your code) and you want to stamp sandboxes
 from it instantly.
 
 A `SandboxTemplate` is a **fluent, immutable recipe**. Every step returns a new
-template, so a base can branch into variants without mutation surprises.
+template, so a base can branch into variants without mutation surprises. It is a pure
+value — no network happens until `build()` or `Sandbox.create(template)`.
 
 ```ts
-// FUTURE
-const base = Sandbox.template("node:20")
+const base = Sandbox.template()
   .withPackages("build-essential", "ffmpeg")
   .workdir("/app");
 
 const withUv = base.run("pip install uv"); // branches; `base` is untouched
+
+const sandbox = await Sandbox.create(base); // builds if cold, forks if warm
 ```
 
-Node-first sugar (`withNode`, `withPython`, `withPackages`, `withEnv`, `workdir`,
-`copy`) keeps the common case to one line; `.run("…")` is the raw escape hatch for any
-build step; `.toDockerfile()` prints exactly what will be built, for transparency.
+Live today: `.run("…")` (the raw escape hatch), `.withPackages(…)`, `.withEnv(…)`,
+`.workdir(…)`, and `template.build()`. Builds run server-side on the default base
+image, content-addressed and cached — a warm template just forks. Reserved for later:
+custom base images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
+`withPython`, `copy`), and `.toDockerfile()` transparency.
 
 > The types are named `SandboxTemplate` / `SandboxBase` — never a bare `Template` —
 > because the broader `railway` SDK will also wrap Railway's project-template system,
@@ -268,6 +272,9 @@ All SDK errors extend `RailwayError`:
 | `RailwayAuthError` | A required credential (`token` / `environmentId`) could not be resolved. Carries `.variable`. |
 | `RailwayGraphQLError` | The Railway API returned an error. Carries `.status`, `.errors`, `.responseBody`. |
 | `SandboxNotFoundError` | `connect` / `refresh` could not find the sandbox in the environment. Carries `.id`, `.environmentId`. |
+| `SandboxFailedError` | A sandbox reached a terminal state (`FAILED`/`DESTROYED`) before becoming `RUNNING` during `create`. Carries `.id`, `.status`. |
+| `SandboxTemplateBuildError` | A template build finished `FAILED`. Carries `.templateId`, `.environmentId`. |
+| `SandboxTimeoutError` | A readiness wait (template → `READY` or sandbox → `RUNNING`) exceeded the 5-minute ceiling. Carries `.resource`, `.id`, `.lastStatus`, `.timeoutMs`. |
 | `SandboxFileNotFoundError` / `SandboxFileTooLargeError` _(future)_ | File operations. |
 
 ---
@@ -285,7 +292,7 @@ that shipping it flips on a network call — never a breaking type change.
 | Env-resolved config + `RailwayAuthError` | **Live** |
 | `Sandbox.connect(id)` / `Sandbox.list()` / `sandbox.refresh()` | **Live** |
 | `sandbox.files.*` | Future |
-| `Sandbox.template()` / `SandboxTemplate` / `create(template)` | Future |
+| `Sandbox.template()` / `SandboxTemplate` / `create(template)` | **Live** |
 | `sandbox.fork()` / `create(sandbox)` / `create({ image })` | Future |
 | `sandbox.expose(port)` / `unexpose` / `exposedPorts` | Future |
 | `exec` streaming (`{ stream }`) and background (`{ background }`) | Future |
@@ -302,6 +309,9 @@ import {
   RailwayAuthError,
   RailwayGraphQLError,
   SandboxNotFoundError,
+  SandboxFailedError,
+  SandboxTemplateBuildError,
+  SandboxTimeoutError,
   DEFAULT_RAILWAY_GRAPHQL_ENDPOINT,
   type CreateOptions,
   type ConnectOptions,
@@ -310,6 +320,10 @@ import {
   type ExecResult,
   type SandboxInfo,
   type SandboxStatus,
+  type SandboxTemplate,
+  type SandboxTemplateInfo,
+  type SandboxTemplateStatus,
+  type TemplateBuildOptions,
   type RailwayClientConfig,
   type RailwayGraphQLErrorItem,
 } from "railway";
@@ -317,9 +331,11 @@ import {
 
 ```ts
 class Sandbox {
+  static create(template: SandboxTemplate, options?: CreateOptions): Promise<Sandbox>;
   static create(options?: CreateOptions): Promise<Sandbox>;
   static connect(id: string, options?: ConnectOptions): Promise<Sandbox>;
   static list(options?: ListOptions): Promise<SandboxInfo[]>;
+  static template(): SandboxTemplate;
 
   readonly id: string;
   readonly status: SandboxStatus;
@@ -333,5 +349,15 @@ class Sandbox {
   refresh(): Promise<this>;
   [Symbol.asyncDispose](): Promise<void>;
   toJSON(): SandboxInfo;
+}
+
+// Fluent, immutable recipe — every builder returns a new template. Obtain one
+// via `Sandbox.template()`; it is a pure value and does no network until built.
+interface SandboxTemplate {
+  run(command: string): SandboxTemplate;
+  withPackages(...packages: string[]): SandboxTemplate;
+  withEnv(vars: Record<string, string>): SandboxTemplate;
+  workdir(dir: string): SandboxTemplate;
+  build(options?: TemplateBuildOptions): Promise<SandboxTemplate>;
 }
 ```

--- a/examples/sandboxes/helpers.ts
+++ b/examples/sandboxes/helpers.ts
@@ -12,6 +12,8 @@ export async function runExample(example: () => Promise<void>): Promise<void> {
 }
 
 function formatError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
   if (error instanceof RailwayAuthError) {
     return `${error.message} Copy .env.example to .env first.`;
   }
@@ -20,10 +22,10 @@ function formatError(error: unknown): string {
     return `Railway GraphQL error: ${error.message}`;
   }
 
-  if (!(error instanceof Error)) {
-    return String(error);
-  }
+  return formatGenericError(error);
+}
 
+function formatGenericError(error: Error): string {
   if (hasErrorCode(error.cause, "SELF_SIGNED_CERT_IN_CHAIN")) {
     return `${error.message}: self-signed certificate in chain. Run examples with mise so Node uses the project CA settings.`;
   }

--- a/examples/sandboxes/template.ts
+++ b/examples/sandboxes/template.ts
@@ -1,0 +1,19 @@
+import { Sandbox } from "../../src/index.ts";
+import { runExample } from "./helpers.ts";
+
+await runExample(async () => {
+  // A template is a pure, immutable recipe — no network until it is built/created.
+  const base = Sandbox.template().withPackages("ffmpeg").workdir("/app");
+
+  // Same call whether the template is cold (builds, then forks) or warm (just
+  // forks). `await using` destroys the sandbox automatically on scope exit.
+  await using sandbox = await Sandbox.create(base);
+
+  console.log((await sandbox.exec("ffmpeg -version")).stdout);
+  console.log((await sandbox.exec("pwd")).stdout); // /app
+
+  // Optional explicit pre-warm — build once, stamp many instantly:
+  //   await base.build();
+  //   const a = await Sandbox.create(base); // already built → fast fork
+  //   const b = await Sandbox.create(base);
+});

--- a/examples/sandboxes/template.ts
+++ b/examples/sandboxes/template.ts
@@ -2,18 +2,10 @@ import { Sandbox } from "../../src/index.ts";
 import { runExample } from "./helpers.ts";
 
 await runExample(async () => {
-  // A template is a pure, immutable recipe — no network until it is built/created.
   const base = Sandbox.template().withPackages("ffmpeg").workdir("/app");
 
-  // Same call whether the template is cold (builds, then forks) or warm (just
-  // forks). `await using` destroys the sandbox automatically on scope exit.
   await using sandbox = await Sandbox.create(base);
 
   console.log((await sandbox.exec("ffmpeg -version")).stdout);
-  console.log((await sandbox.exec("pwd")).stdout); // /app
-
-  // Optional explicit pre-warm — build once, stamp many instantly:
-  //   await base.build();
-  //   const a = await Sandbox.create(base); // already built → fast fork
-  //   const b = await Sandbox.create(base);
+  console.log((await sandbox.exec("pwd")).stdout);
 });

--- a/mise.toml
+++ b/mise.toml
@@ -58,3 +58,7 @@ depends = ["example:quickstart"]
 description = "Create a sandbox, exec a command, then destroy it using .env credentials"
 run = "pnpm exec tsx examples/sandboxes/quickstart.ts"
 
+[tasks."example:template"]
+description = "Build a template, create a sandbox from it, then destroy it using .env credentials"
+run = "pnpm exec tsx examples/sandboxes/template.ts"
+

--- a/mise.toml
+++ b/mise.toml
@@ -59,6 +59,6 @@ description = "Create a sandbox, exec a command, then destroy it using .env cred
 run = "pnpm exec tsx examples/sandboxes/quickstart.ts"
 
 [tasks."example:template"]
-description = "Build a template, create a sandbox from it, then destroy it using .env credentials"
+description = "Create a sandbox from a template, then destroy it using .env credentials"
 run = "pnpm exec tsx examples/sandboxes/template.ts"
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1926,6 +1926,7 @@ export type EdgeCachingConfig = {
   defaultTtlSeconds: Scalars['Int']['output'];
   htmlCaching: Scalars['String']['output'];
   mode: Scalars['String']['output'];
+  purgeOnDeploy: PurgeOnDeploy;
   staleWhileRevalidate: StaleWhileRevalidateConfig;
 };
 
@@ -1933,6 +1934,7 @@ export type EdgeCachingConfigInput = {
   defaultTtlSeconds?: InputMaybe<Scalars['Int']['input']>;
   htmlCaching?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<Scalars['String']['input']>;
+  purgeOnDeploy?: InputMaybe<PurgeOnDeploy>;
   staleWhileRevalidate?: InputMaybe<StaleWhileRevalidateInput>;
 };
 
@@ -1941,6 +1943,8 @@ export type EdgeConfig = {
   caching?: Maybe<EdgeCachingConfig>;
   enabled: Scalars['Boolean']['output'];
   id: Scalars['String']['output'];
+  purgeEpoch: Scalars['Int']['output'];
+  purgeEpochByKind: Scalars['JSON']['output'];
 };
 
 export type EdgeConfigInput = {
@@ -4347,6 +4351,8 @@ export type Mutation = {
   projectUpdate: Project;
   /** Deletes a ProviderAuth. */
   providerAuthRemove: Scalars['Boolean']['output'];
+  /** Purges the CDN cache for a service. Bumps the edge config's purge epoch so every edge node treats prior cached entries as stale on next request. Idempotent; returns true even if CDN is disabled for the service. */
+  purgeServiceCache: Scalars['Boolean']['output'];
   /** Register an Expo push notification token for the current user */
   pushTokenRegister: Scalars['Boolean']['output'];
   /** Unregister an Expo push notification token for the current user */
@@ -4409,6 +4415,8 @@ export type Mutation = {
   sandboxDestroy?: Maybe<Sandbox>;
   /** Execute a command inside a running sandbox. */
   sandboxExec: SandboxExecResult;
+  /** Build (or return) a content-addressed sandbox template. Idempotent and non-blocking: starts the build if needed and returns immediately; poll `sandboxTemplate` until READY. */
+  sandboxTemplateBuild: SandboxTemplate;
   /** Send a notification email to user when bounty is won */
   sendBountyWonEmail: Scalars['Boolean']['output'];
   /** Send a community thread notification email */
@@ -6225,6 +6233,11 @@ export type MutationProviderAuthRemoveArgs = {
 };
 
 
+export type MutationPurgeServiceCacheArgs = {
+  input: PurgeServiceCacheInput;
+};
+
+
 export type MutationPushTokenRegisterArgs = {
   token: Scalars['String']['input'];
 };
@@ -6408,6 +6421,12 @@ export type MutationSandboxExecArgs = {
   environmentId: Scalars['String']['input'];
   id: Scalars['String']['input'];
   timeoutSec?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type MutationSandboxTemplateBuildArgs = {
+  environmentId: Scalars['String']['input'];
+  input: SandboxTemplateInput;
 };
 
 
@@ -9119,6 +9138,21 @@ export type PublicStatsEvent = {
   value: Scalars['BigInt']['output'];
 };
 
+export type PurgeCacheScope =
+  | 'ALL'
+  | 'HTML';
+
+export type PurgeOnDeploy =
+  | 'ALL'
+  | 'HTML'
+  | 'OFF';
+
+export type PurgeServiceCacheInput = {
+  environmentId: Scalars['String']['input'];
+  scope: PurgeCacheScope;
+  serviceId: Scalars['String']['input'];
+};
+
 export type Query = {
   __typename?: 'Query';
   /**
@@ -9611,6 +9645,8 @@ export type Query = {
   resourceAccess: ResourceAccess;
   /** Get a sandbox by id. */
   sandbox?: Maybe<Sandbox>;
+  /** Get the status of a sandbox template by its content-addressed id. Cheap and side-effect-free; poll this until READY. */
+  sandboxTemplate: SandboxTemplate;
   /** List sandboxes in an environment. */
   sandboxes: QuerySandboxesConnection;
   /** Search published templates by name or description */
@@ -11079,6 +11115,12 @@ export type QueryResourceAccessArgs = {
 export type QuerySandboxArgs = {
   environmentId: Scalars['String']['input'];
   id: Scalars['String']['input'];
+};
+
+
+export type QuerySandboxTemplateArgs = {
+  environmentId: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
 };
 
 
@@ -12764,6 +12806,7 @@ export type Sandbox = {
 export type SandboxCreateInput = {
   environmentId: Scalars['String']['input'];
   idleTimeoutMinutes?: InputMaybe<Scalars['Int']['input']>;
+  template?: InputMaybe<SandboxTemplateInput>;
 };
 
 export type SandboxExecResult = {
@@ -12781,6 +12824,24 @@ export type SandboxStatus =
   | 'DESTROYING'
   | 'FAILED'
   | 'RUNNING';
+
+export type SandboxTemplate = {
+  __typename?: 'SandboxTemplate';
+  environmentId: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  status: SandboxTemplateStatus;
+};
+
+export type SandboxTemplateInput = {
+  baseImageDigest?: InputMaybe<Scalars['String']['input']>;
+  instructions: Array<Scalars['String']['input']>;
+};
+
+export type SandboxTemplateStatus =
+  | 'BUILDING'
+  | 'FAILED'
+  | 'PENDING'
+  | 'READY';
 
 export type SendBountyWonEmailInput = {
   bountyAmount: Scalars['Float']['input'];
@@ -15355,9 +15416,30 @@ export type RailwaySandboxDestroyMutationVariables = Exact<{
 
 export type RailwaySandboxDestroyMutation = { __typename?: 'Mutation', sandboxDestroy?: { __typename?: 'Sandbox', id: string, status: SandboxStatus, environmentId: string, region: string, idleTimeoutMinutes?: number | null, createdAt: string } | null };
 
+export type RailwaySandboxTemplateFieldsFragment = { __typename?: 'SandboxTemplate', id: string, status: SandboxTemplateStatus, environmentId: string };
+
+export type RailwaySandboxTemplateBuildMutationVariables = Exact<{
+  environmentId: Scalars['String']['input'];
+  input: SandboxTemplateInput;
+}>;
+
+
+export type RailwaySandboxTemplateBuildMutation = { __typename?: 'Mutation', sandboxTemplateBuild: { __typename?: 'SandboxTemplate', id: string, status: SandboxTemplateStatus, environmentId: string } };
+
+export type RailwaySandboxTemplateQueryVariables = Exact<{
+  environmentId: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type RailwaySandboxTemplateQuery = { __typename?: 'Query', sandboxTemplate: { __typename?: 'SandboxTemplate', id: string, status: SandboxTemplateStatus, environmentId: string } };
+
 export const RailwaySandboxFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Sandbox"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}},{"kind":"Field","name":{"kind":"Name","value":"region"}},{"kind":"Field","name":{"kind":"Name","value":"idleTimeoutMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<RailwaySandboxFieldsFragment, unknown>;
+export const RailwaySandboxTemplateFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxTemplateFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"SandboxTemplate"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}}]}}]} as unknown as DocumentNode<RailwaySandboxTemplateFieldsFragment, unknown>;
 export const RailwaySandboxDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"RailwaySandbox"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandbox"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}},{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Sandbox"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}},{"kind":"Field","name":{"kind":"Name","value":"region"}},{"kind":"Field","name":{"kind":"Name","value":"idleTimeoutMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<RailwaySandboxQuery, RailwaySandboxQueryVariables>;
 export const RailwaySandboxesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"RailwaySandboxes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"first"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"after"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"before"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"last"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxes"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}},{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"first"}}},{"kind":"Argument","name":{"kind":"Name","value":"after"},"value":{"kind":"Variable","name":{"kind":"Name","value":"after"}}},{"kind":"Argument","name":{"kind":"Name","value":"before"},"value":{"kind":"Variable","name":{"kind":"Name","value":"before"}}},{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"Variable","name":{"kind":"Name","value":"last"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxFields"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"pageInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"endCursor"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Sandbox"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}},{"kind":"Field","name":{"kind":"Name","value":"region"}},{"kind":"Field","name":{"kind":"Name","value":"idleTimeoutMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<RailwaySandboxesQuery, RailwaySandboxesQueryVariables>;
 export const RailwaySandboxCreateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RailwaySandboxCreate"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SandboxCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxCreate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Sandbox"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}},{"kind":"Field","name":{"kind":"Name","value":"region"}},{"kind":"Field","name":{"kind":"Name","value":"idleTimeoutMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<RailwaySandboxCreateMutation, RailwaySandboxCreateMutationVariables>;
 export const RailwaySandboxExecDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RailwaySandboxExec"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"command"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeoutSec"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxExec"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}},{"kind":"Argument","name":{"kind":"Name","value":"command"},"value":{"kind":"Variable","name":{"kind":"Name","value":"command"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeoutSec"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeoutSec"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"exitCode"}},{"kind":"Field","name":{"kind":"Name","value":"stdout"}},{"kind":"Field","name":{"kind":"Name","value":"stderr"}},{"kind":"Field","name":{"kind":"Name","value":"truncated"}},{"kind":"Field","name":{"kind":"Name","value":"timedOut"}}]}}]}}]} as unknown as DocumentNode<RailwaySandboxExecMutation, RailwaySandboxExecMutationVariables>;
 export const RailwaySandboxDestroyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RailwaySandboxDestroy"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxDestroy"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Sandbox"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}},{"kind":"Field","name":{"kind":"Name","value":"region"}},{"kind":"Field","name":{"kind":"Name","value":"idleTimeoutMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<RailwaySandboxDestroyMutation, RailwaySandboxDestroyMutationVariables>;
+export const RailwaySandboxTemplateBuildDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RailwaySandboxTemplateBuild"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SandboxTemplateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxTemplateBuild"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}},{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxTemplateFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxTemplateFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"SandboxTemplate"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}}]}}]} as unknown as DocumentNode<RailwaySandboxTemplateBuildMutation, RailwaySandboxTemplateBuildMutationVariables>;
+export const RailwaySandboxTemplateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"RailwaySandboxTemplate"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sandboxTemplate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"environmentId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentId"}}},{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"RailwaySandboxTemplateFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RailwaySandboxTemplateFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"SandboxTemplate"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"environmentId"}}]}}]} as unknown as DocumentNode<RailwaySandboxTemplateQuery, RailwaySandboxTemplateQueryVariables>;

--- a/src/graphql/operations/sandbox.graphql
+++ b/src/graphql/operations/sandbox.graphql
@@ -70,3 +70,24 @@ mutation RailwaySandboxDestroy($id: String!, $environmentId: String!) {
     ...RailwaySandboxFields
   }
 }
+
+fragment RailwaySandboxTemplateFields on SandboxTemplate {
+  id
+  status
+  environmentId
+}
+
+mutation RailwaySandboxTemplateBuild(
+  $environmentId: String!
+  $input: SandboxTemplateInput!
+) {
+  sandboxTemplateBuild(environmentId: $environmentId, input: $input) {
+    ...RailwaySandboxTemplateFields
+  }
+}
+
+query RailwaySandboxTemplate($environmentId: String!, $id: ID!) {
+  sandboxTemplate(environmentId: $environmentId, id: $id) {
+    ...RailwaySandboxTemplateFields
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,10 @@ export {
 } from "./core/errors.js";
 export {
   Sandbox,
+  SandboxFailedError,
   SandboxNotFoundError,
+  SandboxTemplateBuildError,
+  SandboxTimeoutError,
   type ConnectOptions,
   type CreateOptions,
   type ExecOptions,
@@ -18,4 +21,8 @@ export {
   type ListOptions,
   type SandboxInfo,
   type SandboxStatus,
+  type SandboxTemplate,
+  type SandboxTemplateInfo,
+  type SandboxTemplateStatus,
+  type TemplateBuildOptions,
 } from "./sandbox/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,5 @@ export {
   type SandboxInfo,
   type SandboxStatus,
   type SandboxTemplate,
-  type SandboxTemplateInfo,
-  type SandboxTemplateStatus,
   type TemplateBuildOptions,
 } from "./sandbox/index.js";

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -43,11 +43,10 @@ import type {
   SandboxTemplateInfo,
 } from "./types.js";
 
-/** Readiness wait ceiling — mirrors the server exec timeout cap. Not a public option. */
-const READY_TIMEOUT_MS = 5 * 60_000;
+/** Mirrors the server exec timeout cap. Not a public option. */
+const READINESS_TIMEOUT_MS = 5 * 60_000;
 const POLL_INITIAL_DELAY_MS = 500;
 const POLL_MAX_DELAY_MS = 5_000;
-const POLL_BACKOFF_FACTOR = 2;
 
 const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));
@@ -97,12 +96,12 @@ export class SandboxEngine {
     return this.#waitForRunning(data.sandboxCreate);
   }
 
-  async buildTemplate(input: {
-    instructions: readonly string[];
-  }): Promise<SandboxTemplateInfo> {
+  async buildTemplate(
+    instructions: readonly string[],
+  ): Promise<SandboxTemplateInfo> {
     const variables: RailwaySandboxTemplateBuildMutationVariables = {
       environmentId: this.#config.environmentId,
-      input: { instructions: [...input.instructions] },
+      input: { instructions: [...instructions] },
     };
     const data = await requestGraphQL<
       RailwaySandboxTemplateBuildMutation,
@@ -129,7 +128,7 @@ export class SandboxEngine {
   async buildTemplateUntilReady(
     instructions: readonly string[],
   ): Promise<SandboxTemplateInfo> {
-    const built = await this.buildTemplate({ instructions });
+    const built = await this.buildTemplate(instructions);
     if (built.status === "READY") return built;
     if (built.status === "FAILED") {
       throw new SandboxTemplateBuildError({
@@ -153,7 +152,7 @@ export class SandboxEngine {
           resource: "template",
           id: template.id,
           lastStatus: template.status,
-          timeoutMs: READY_TIMEOUT_MS,
+          timeoutMs: READINESS_TIMEOUT_MS,
         });
       },
     });
@@ -177,7 +176,7 @@ export class SandboxEngine {
           resource: "sandbox",
           id: info.id,
           lastStatus: info.status,
-          timeoutMs: READY_TIMEOUT_MS,
+          timeoutMs: READINESS_TIMEOUT_MS,
         });
       },
     });
@@ -211,8 +210,8 @@ export class SandboxEngine {
       last = await args.poll();
       if (args.isReady(last)) return last;
       if (args.isTerminal(last)) return args.onTerminal(last);
-      delay = Math.min(delay * POLL_BACKOFF_FACTOR, POLL_MAX_DELAY_MS);
-    } while (Date.now() - start < READY_TIMEOUT_MS);
+      delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
+    } while (Date.now() - start < READINESS_TIMEOUT_MS);
     return args.onTimeout(last);
   }
 

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -43,7 +43,6 @@ import type {
   SandboxTemplateInfo,
 } from "./types.js";
 
-/** Mirrors the server exec timeout cap. Not a public option. */
 const READINESS_TIMEOUT_MS = 5 * 60_000;
 const POLL_INITIAL_DELAY_MS = 500;
 const POLL_MAX_DELAY_MS = 5_000;
@@ -60,8 +59,7 @@ export interface SandboxOptions extends RailwayClientConfig {
 }
 
 /**
- * Binds resolved credentials + environment to the sandbox GraphQL operations.
- * Never exported as a public noun — `Sandbox` is the only thing callers hold.
+ * Binds resolved credentials and environment to sandbox GraphQL operations.
  */
 export class SandboxEngine {
   readonly #config: SandboxEngineConfig;
@@ -124,7 +122,6 @@ export class SandboxEngine {
     return data.sandboxTemplate;
   }
 
-  /** Builds the template if needed and resolves only once it is READY. Idempotent. */
   async buildTemplateUntilReady(
     instructions: readonly string[],
   ): Promise<SandboxTemplateInfo> {
@@ -190,11 +187,6 @@ export class SandboxEngine {
     return info;
   }
 
-  /**
-   * Polls `args.poll` with exponential backoff until ready, throwing on a
-   * terminal state or once the readiness ceiling is hit. Shared by both the
-   * template → READY and sandbox → RUNNING waits.
-   */
   async #pollUntilReady<T>(args: {
     poll: () => Promise<T>;
     isReady: (value: T) => boolean;

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -11,6 +11,8 @@ import {
   RailwaySandboxDocument,
   RailwaySandboxesDocument,
   RailwaySandboxExecDocument,
+  RailwaySandboxTemplateBuildDocument,
+  RailwaySandboxTemplateDocument,
   type RailwaySandboxCreateMutation,
   type RailwaySandboxCreateMutationVariables,
   type RailwaySandboxDestroyMutation,
@@ -21,14 +23,34 @@ import {
   type RailwaySandboxesQueryVariables,
   type RailwaySandboxQuery,
   type RailwaySandboxQueryVariables,
+  type RailwaySandboxTemplateBuildMutation,
+  type RailwaySandboxTemplateBuildMutationVariables,
+  type RailwaySandboxTemplateQuery,
+  type RailwaySandboxTemplateQueryVariables,
 } from "../generated/graphql.js";
+import {
+  SandboxFailedError,
+  SandboxNotFoundError,
+  SandboxTemplateBuildError,
+  SandboxTimeoutError,
+} from "./errors.js";
 import type {
   CreateOptions,
   ExecOptions,
   ExecResult,
   ListOptions,
   SandboxInfo,
+  SandboxTemplateInfo,
 } from "./types.js";
+
+/** Readiness wait ceiling — mirrors the server exec timeout cap. Not a public option. */
+const READY_TIMEOUT_MS = 5 * 60_000;
+const POLL_INITIAL_DELAY_MS = 500;
+const POLL_MAX_DELAY_MS = 5_000;
+const POLL_BACKOFF_FACTOR = 2;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
 
 interface SandboxEngineConfig extends NormalizedRailwayClientConfig {
   environmentId: string;
@@ -53,12 +75,18 @@ export class SandboxEngine {
     return this.#config.environmentId;
   }
 
-  async create(options: CreateOptions = {}): Promise<SandboxInfo> {
+  async create(
+    options: CreateOptions = {},
+    templateInstructions?: readonly string[],
+  ): Promise<SandboxInfo> {
     const input: RailwaySandboxCreateMutationVariables["input"] = {
       environmentId: this.#config.environmentId,
     };
     if (options.idleTimeoutMinutes !== undefined) {
       input.idleTimeoutMinutes = options.idleTimeoutMinutes;
+    }
+    if (templateInstructions !== undefined) {
+      input.template = { instructions: [...templateInstructions] };
     }
 
     const data = await requestGraphQL<
@@ -66,7 +94,126 @@ export class SandboxEngine {
       RailwaySandboxCreateMutationVariables
     >(this.#config, RailwaySandboxCreateDocument, { input });
 
-    return data.sandboxCreate;
+    return this.#waitForRunning(data.sandboxCreate);
+  }
+
+  async buildTemplate(input: {
+    instructions: readonly string[];
+  }): Promise<SandboxTemplateInfo> {
+    const variables: RailwaySandboxTemplateBuildMutationVariables = {
+      environmentId: this.#config.environmentId,
+      input: { instructions: [...input.instructions] },
+    };
+    const data = await requestGraphQL<
+      RailwaySandboxTemplateBuildMutation,
+      RailwaySandboxTemplateBuildMutationVariables
+    >(this.#config, RailwaySandboxTemplateBuildDocument, variables);
+
+    return data.sandboxTemplateBuild;
+  }
+
+  async getTemplate(id: string): Promise<SandboxTemplateInfo> {
+    const variables: RailwaySandboxTemplateQueryVariables = {
+      id,
+      environmentId: this.#config.environmentId,
+    };
+    const data = await requestGraphQL<
+      RailwaySandboxTemplateQuery,
+      RailwaySandboxTemplateQueryVariables
+    >(this.#config, RailwaySandboxTemplateDocument, variables);
+
+    return data.sandboxTemplate;
+  }
+
+  /** Builds the template if needed and resolves only once it is READY. Idempotent. */
+  async buildTemplateUntilReady(
+    instructions: readonly string[],
+  ): Promise<SandboxTemplateInfo> {
+    const built = await this.buildTemplate({ instructions });
+    if (built.status === "READY") return built;
+    if (built.status === "FAILED") {
+      throw new SandboxTemplateBuildError({
+        templateId: built.id,
+        environmentId: this.environmentId,
+      });
+    }
+
+    return this.#pollUntilReady({
+      poll: () => this.getTemplate(built.id),
+      isReady: template => template.status === "READY",
+      isTerminal: template => template.status === "FAILED",
+      onTerminal: template => {
+        throw new SandboxTemplateBuildError({
+          templateId: template.id,
+          environmentId: this.environmentId,
+        });
+      },
+      onTimeout: template => {
+        throw new SandboxTimeoutError({
+          resource: "template",
+          id: template.id,
+          lastStatus: template.status,
+          timeoutMs: READY_TIMEOUT_MS,
+        });
+      },
+    });
+  }
+
+  async #waitForRunning(created: SandboxInfo): Promise<SandboxInfo> {
+    if (created.status === "RUNNING") return created;
+    if (isSandboxTerminal(created.status)) {
+      throw new SandboxFailedError({ id: created.id, status: created.status });
+    }
+
+    return this.#pollUntilReady({
+      poll: () => this.#getOrThrow(created.id),
+      isReady: info => info.status === "RUNNING",
+      isTerminal: info => isSandboxTerminal(info.status),
+      onTerminal: info => {
+        throw new SandboxFailedError({ id: info.id, status: info.status });
+      },
+      onTimeout: info => {
+        throw new SandboxTimeoutError({
+          resource: "sandbox",
+          id: info.id,
+          lastStatus: info.status,
+          timeoutMs: READY_TIMEOUT_MS,
+        });
+      },
+    });
+  }
+
+  async #getOrThrow(id: string): Promise<SandboxInfo> {
+    const info = await this.get(id);
+    if (!info) {
+      throw new SandboxNotFoundError({ id, environmentId: this.environmentId });
+    }
+    return info;
+  }
+
+  /**
+   * Polls `args.poll` with exponential backoff until ready, throwing on a
+   * terminal state or once the readiness ceiling is hit. Shared by both the
+   * template → READY and sandbox → RUNNING waits.
+   */
+  async #pollUntilReady<T>(args: {
+    poll: () => Promise<T>;
+    isReady: (value: T) => boolean;
+    isTerminal: (value: T) => boolean;
+    onTerminal: (value: T) => never;
+    onTimeout: (value: T) => never;
+  }): Promise<T> {
+    const start = Date.now();
+    let delay = POLL_INITIAL_DELAY_MS;
+    let last: T;
+    do {
+      await sleep(delay);
+      last = await args.poll();
+      if (args.isReady(last)) return last;
+      if (args.isTerminal(last)) return args.onTerminal(last);
+      delay = Math.min(delay * POLL_BACKOFF_FACTOR, POLL_MAX_DELAY_MS);
+    } while (Date.now() - start < READY_TIMEOUT_MS);
+    return args.onTimeout(last);
   }
 
   async exec(
@@ -127,6 +274,10 @@ export class SandboxEngine {
 
     return data.sandboxes.edges.map(edge => edge.node);
   }
+}
+
+function isSandboxTerminal(status: SandboxInfo["status"]): boolean {
+  return status === "FAILED" || status === "DESTROYED" || status === "DESTROYING";
 }
 
 export function engineFromOptions(options: SandboxOptions = {}): SandboxEngine {

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -1,4 +1,5 @@
 import { RailwayError } from "../core/errors.js";
+import type { SandboxStatus } from "./types.js";
 
 export class SandboxNotFoundError extends RailwayError {
   readonly id: string;
@@ -10,5 +11,54 @@ export class SandboxNotFoundError extends RailwayError {
     );
     this.id = args.id;
     this.environmentId = args.environmentId;
+  }
+}
+
+/** A sandbox reached a terminal failure state (FAILED/DESTROYED) before becoming RUNNING. */
+export class SandboxFailedError extends RailwayError {
+  readonly id: string;
+  readonly status: SandboxStatus;
+
+  constructor(args: { id: string; status: SandboxStatus }) {
+    super(`Sandbox "${args.id}" entered terminal state "${args.status}" before becoming ready.`);
+    this.id = args.id;
+    this.status = args.status;
+  }
+}
+
+/** A server-side template build finished in the FAILED state. */
+export class SandboxTemplateBuildError extends RailwayError {
+  readonly templateId: string;
+  readonly environmentId: string;
+
+  constructor(args: { templateId: string; environmentId: string }) {
+    super(
+      `Sandbox template "${args.templateId}" failed to build in environment "${args.environmentId}".`,
+    );
+    this.templateId = args.templateId;
+    this.environmentId = args.environmentId;
+  }
+}
+
+/** A readiness wait (template → READY or sandbox → RUNNING) exceeded the time ceiling. */
+export class SandboxTimeoutError extends RailwayError {
+  readonly resource: "sandbox" | "template";
+  readonly id: string;
+  readonly lastStatus: string;
+  readonly timeoutMs: number;
+
+  constructor(args: {
+    resource: "sandbox" | "template";
+    id: string;
+    lastStatus: string;
+    timeoutMs: number;
+  }) {
+    super(
+      `Timed out after ${args.timeoutMs}ms waiting for ${args.resource} "${args.id}" to become ready (last status: ${args.lastStatus}).`,
+    );
+    this.resource = args.resource;
+    this.id = args.id;
+    this.lastStatus = args.lastStatus;
+    this.timeoutMs = args.timeoutMs;
   }
 }

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -14,13 +14,15 @@ export class SandboxNotFoundError extends RailwayError {
   }
 }
 
-/** A sandbox reached a terminal failure state (FAILED/DESTROYED) before becoming RUNNING. */
+/** A sandbox reached FAILED/DESTROYING/DESTROYED before becoming RUNNING. */
 export class SandboxFailedError extends RailwayError {
   readonly id: string;
   readonly status: SandboxStatus;
 
   constructor(args: { id: string; status: SandboxStatus }) {
-    super(`Sandbox "${args.id}" entered terminal state "${args.status}" before becoming ready.`);
+    super(
+      `Sandbox "${args.id}" entered terminal state "${args.status}" before becoming ready.`,
+    );
     this.id = args.id;
     this.status = args.status;
   }
@@ -40,7 +42,7 @@ export class SandboxTemplateBuildError extends RailwayError {
   }
 }
 
-/** A readiness wait (template → READY or sandbox → RUNNING) exceeded the time ceiling. */
+/** A readiness wait exceeded the time ceiling. */
 export class SandboxTimeoutError extends RailwayError {
   readonly resource: "sandbox" | "template";
   readonly id: string;
@@ -54,7 +56,8 @@ export class SandboxTimeoutError extends RailwayError {
     timeoutMs: number;
   }) {
     super(
-      `Timed out after ${args.timeoutMs}ms waiting for ${args.resource} "${args.id}" to become ready (last status: ${args.lastStatus}).`,
+      `Timed out after ${args.timeoutMs}ms waiting for ${args.resource} "${args.id}" ` +
+        `to become ready (last status: ${args.lastStatus}).`,
     );
     this.resource = args.resource;
     this.id = args.id;

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -42,7 +42,7 @@ export class SandboxTemplateBuildError extends RailwayError {
   }
 }
 
-/** A readiness wait exceeded the time ceiling. */
+/** A readiness wait timed out. */
 export class SandboxTimeoutError extends RailwayError {
   readonly resource: "sandbox" | "template";
   readonly id: string;

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -14,7 +14,5 @@ export type {
   ListOptions,
   SandboxInfo,
   SandboxStatus,
-  SandboxTemplateInfo,
-  SandboxTemplateStatus,
   TemplateBuildOptions,
 } from "./types.js";

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,11 @@
 export { Sandbox } from "./sandbox.js";
-export { SandboxNotFoundError } from "./errors.js";
+export {
+  SandboxFailedError,
+  SandboxNotFoundError,
+  SandboxTemplateBuildError,
+  SandboxTimeoutError,
+} from "./errors.js";
+export type { SandboxTemplate } from "./template.js";
 export type {
   ConnectOptions,
   CreateOptions,
@@ -8,4 +14,7 @@ export type {
   ListOptions,
   SandboxInfo,
   SandboxStatus,
+  SandboxTemplateInfo,
+  SandboxTemplateStatus,
+  TemplateBuildOptions,
 } from "./types.js";

--- a/src/sandbox/internal.ts
+++ b/src/sandbox/internal.ts
@@ -1,6 +1,0 @@
-/**
- * Internal-only symbol used to read a template's compiled `instructions` from
- * `Sandbox.create` and tests without exposing the compiled form as public API.
- * Never re-export this from a package barrel.
- */
-export const COMPILE = Symbol("railway.sandbox.template.compile");

--- a/src/sandbox/internal.ts
+++ b/src/sandbox/internal.ts
@@ -1,0 +1,6 @@
+/**
+ * Internal-only symbol used to read a template's compiled `instructions` from
+ * `Sandbox.create` and tests without exposing the compiled form as public API.
+ * Never re-export this from a package barrel.
+ */
+export const COMPILE = Symbol("railway.sandbox.template.compile");

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -3,8 +3,12 @@ import {
   type SandboxEngine,
 } from "./engine.js";
 import { SandboxNotFoundError } from "./errors.js";
-import { COMPILE } from "./internal.js";
-import { SandboxTemplate } from "./template.js";
+import {
+  compileSandboxTemplate,
+  createSandboxTemplate,
+  isSandboxTemplate,
+  type SandboxTemplate,
+} from "./template.js";
 import type {
   ConnectOptions,
   CreateOptions,
@@ -54,9 +58,9 @@ export class Sandbox implements AsyncDisposable {
     return this.#info.createdAt;
   }
 
-  /** A reusable, immutable template recipe. Pure value — no network until built. */
+  /** Return a new immutable sandbox template. */
   static template(): SandboxTemplate {
-    return SandboxTemplate.blank();
+    return createSandboxTemplate();
   }
 
   static create(
@@ -68,9 +72,9 @@ export class Sandbox implements AsyncDisposable {
     sourceOrOptions: SandboxTemplate | CreateOptions = {},
     maybeOptions: CreateOptions = {},
   ): Promise<Sandbox> {
-    if (sourceOrOptions instanceof SandboxTemplate) {
+    if (isSandboxTemplate(sourceOrOptions)) {
       const engine = engineFromOptions(maybeOptions);
-      const instructions = sourceOrOptions[COMPILE]();
+      const instructions = compileSandboxTemplate(sourceOrOptions);
       await engine.buildTemplateUntilReady(instructions);
       const info = await engine.create(maybeOptions, instructions);
       return new Sandbox(engine, info);

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -3,6 +3,8 @@ import {
   type SandboxEngine,
 } from "./engine.js";
 import { SandboxNotFoundError } from "./errors.js";
+import { COMPILE } from "./internal.js";
+import { SandboxTemplate } from "./template.js";
 import type {
   ConnectOptions,
   CreateOptions,
@@ -51,9 +53,30 @@ export class Sandbox implements AsyncDisposable {
     return this.#info.createdAt;
   }
 
-  static async create(options: CreateOptions = {}): Promise<Sandbox> {
-    const engine = engineFromOptions(options);
-    const info = await engine.create(options);
+  /** A reusable, immutable template recipe. Pure value — no network until built. */
+  static template(): SandboxTemplate {
+    return SandboxTemplate.blank();
+  }
+
+  static create(
+    template: SandboxTemplate,
+    options?: CreateOptions,
+  ): Promise<Sandbox>;
+  static create(options?: CreateOptions): Promise<Sandbox>;
+  static async create(
+    sourceOrOptions: SandboxTemplate | CreateOptions = {},
+    maybeOptions: CreateOptions = {},
+  ): Promise<Sandbox> {
+    if (sourceOrOptions instanceof SandboxTemplate) {
+      const engine = engineFromOptions(maybeOptions);
+      const instructions = sourceOrOptions[COMPILE]();
+      await engine.buildTemplateUntilReady(instructions);
+      const info = await engine.create(maybeOptions, instructions);
+      return new Sandbox(engine, info);
+    }
+
+    const engine = engineFromOptions(sourceOrOptions);
+    const info = await engine.create(sourceOrOptions);
     return new Sandbox(engine, info);
   }
 

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -18,7 +18,8 @@ import type {
 /**
  * A live Railway sandbox. There is no separate client: a sandbox always comes
  * from somewhere — nothing (`Sandbox.create`), an id (`Sandbox.connect`), or a
- * reusable base (future). The constructor is private; use the static factories.
+ * reusable base (`Sandbox.template()`). The constructor is private; use the
+ * static factories.
  */
 export class Sandbox implements AsyncDisposable {
   readonly #engine: SandboxEngine;

--- a/src/sandbox/template.ts
+++ b/src/sandbox/template.ts
@@ -1,0 +1,119 @@
+import { engineFromOptions } from "./engine.js";
+import { COMPILE } from "./internal.js";
+import type { TemplateBuildOptions } from "./types.js";
+
+/** Ambient build state carried forward by the immutable builder. */
+interface TemplateState {
+  readonly instructions: readonly string[];
+  /** Ordered [key, value] pairs; insertion order preserved, override-in-place. */
+  readonly env: ReadonlyArray<readonly [string, string]>;
+  readonly workdir?: string;
+}
+
+const EMPTY_STATE: TemplateState = { instructions: [], env: [] };
+
+/**
+ * A fluent, immutable recipe for a server-side sandbox base. Every builder step
+ * returns a NEW template — nothing mutates in place — so a base can branch into
+ * variants safely. Obtain one with `Sandbox.template()`; it is a pure value and
+ * does no network until `build()` or `Sandbox.create(template)`.
+ *
+ * Each instruction runs in its own shell server-side, so `env`/`workdir` do not
+ * persist between instructions — they are folded into every subsequent command.
+ */
+export class SandboxTemplate {
+  readonly #state: TemplateState;
+
+  private constructor(state: TemplateState) {
+    this.#state = state;
+  }
+
+  /** Internal entry used by `Sandbox.template()`. Not reachable by consumers. */
+  static blank(): SandboxTemplate {
+    return new SandboxTemplate(EMPTY_STATE);
+  }
+
+  /** Runs a raw shell command as a build step. */
+  run(command: string): SandboxTemplate {
+    return this.#append(command);
+  }
+
+  /** Installs Debian packages via apt (the base image ships no apt index). */
+  withPackages(...packages: string[]): SandboxTemplate {
+    if (packages.length === 0) return this;
+    return this.#append(
+      `apt-get update && apt-get install -y --no-install-recommends ${packages.join(" ")}`,
+    );
+  }
+
+  /** Sets environment variables folded into every subsequent build step. */
+  withEnv(vars: Record<string, string>): SandboxTemplate {
+    let env = this.#state.env;
+    for (const [key, value] of Object.entries(vars)) {
+      env = upsertEnv(env, key, value);
+    }
+    return new SandboxTemplate({ ...this.#state, env });
+  }
+
+  /** Sets the working directory for every subsequent build step. */
+  workdir(dir: string): SandboxTemplate {
+    return new SandboxTemplate({ ...this.#state, workdir: dir });
+  }
+
+  /** Builds the template server-side, resolving only once it is READY. Returns itself for chaining. */
+  async build(options: TemplateBuildOptions = {}): Promise<SandboxTemplate> {
+    const engine = engineFromOptions(options);
+    await engine.buildTemplateUntilReady(this[COMPILE]());
+    return this;
+  }
+
+  /** @internal compiled instructions, read by `Sandbox.create`. */
+  [COMPILE](): string[] {
+    return [...this.#state.instructions];
+  }
+
+  #append(command: string): SandboxTemplate {
+    const instruction = compile(command, this.#state.env, this.#state.workdir);
+    return new SandboxTemplate({
+      ...this.#state,
+      instructions: [...this.#state.instructions, instruction],
+    });
+  }
+}
+
+/**
+ * Folds accumulated env + active workdir into a single instruction. Each
+ * instruction is a fresh shell server-side, so exports and `cd` are re-applied
+ * per step; the workdir is created (`mkdir -p`) so `cd` always succeeds.
+ */
+function compile(
+  command: string,
+  env: ReadonlyArray<readonly [string, string]>,
+  workdir: string | undefined,
+): string {
+  const parts: string[] = [];
+  for (const [key, value] of env) parts.push(`export ${key}=${shellQuote(value)}`);
+  if (workdir !== undefined) {
+    const quoted = shellQuote(workdir);
+    parts.push(`mkdir -p ${quoted}`, `cd ${quoted}`);
+  }
+  parts.push(command);
+  return parts.join(" && ");
+}
+
+function upsertEnv(
+  env: ReadonlyArray<readonly [string, string]>,
+  key: string,
+  value: string,
+): ReadonlyArray<readonly [string, string]> {
+  const index = env.findIndex(([k]) => k === key);
+  if (index === -1) return [...env, [key, value]];
+  const next = env.slice();
+  next[index] = [key, value];
+  return next;
+}
+
+/** POSIX single-quote escaping so values with spaces/quotes survive the shell. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/src/sandbox/template.ts
+++ b/src/sandbox/template.ts
@@ -1,44 +1,54 @@
 import { engineFromOptions } from "./engine.js";
-import { COMPILE } from "./internal.js";
 import type { TemplateBuildOptions } from "./types.js";
 
-/** Ambient build state carried forward by the immutable builder. */
 interface TemplateState {
   readonly instructions: readonly string[];
-  /** Ordered [key, value] pairs; insertion order preserved, override-in-place. */
   readonly env: ReadonlyArray<readonly [string, string]>;
   readonly workdir?: string;
 }
 
 const EMPTY_STATE: TemplateState = { instructions: [], env: [] };
 
-/**
- * A fluent, immutable recipe for a server-side sandbox base. Every builder step
- * returns a new template, so a base can branch into variants safely. Obtain one
- * with `Sandbox.template()`; it is a pure value and does no network until
- * `build()` or `Sandbox.create(template)`.
- *
- * Each instruction runs in its own shell server-side, so `env`/`workdir` do not
- * persist between instructions — they are folded into every subsequent command.
- */
-export class SandboxTemplate {
+/** Immutable sandbox base recipe returned by `Sandbox.template()`. */
+export interface SandboxTemplate {
+  /** Add a shell command build step. */
+  run(command: string): SandboxTemplate;
+  /** Install Debian packages with apt. */
+  withPackages(...packages: string[]): SandboxTemplate;
+  /** Set environment variables for later build steps. */
+  withEnv(vars: Record<string, string>): SandboxTemplate;
+  /** Set the working directory for later build steps. */
+  workdir(dir: string): SandboxTemplate;
+  /** Build the template before creating sandboxes from it. */
+  build(options?: TemplateBuildOptions): Promise<SandboxTemplate>;
+}
+
+export function createSandboxTemplate(): SandboxTemplate {
+  return new SandboxTemplateRecipe(EMPTY_STATE);
+}
+
+export function isSandboxTemplate(value: unknown): value is SandboxTemplate {
+  return value instanceof SandboxTemplateRecipe;
+}
+
+export function compileSandboxTemplate(template: SandboxTemplate): string[] {
+  if (!(template instanceof SandboxTemplateRecipe)) {
+    throw new TypeError("Expected a SandboxTemplate returned by Sandbox.template().");
+  }
+  return template.compile();
+}
+
+class SandboxTemplateRecipe implements SandboxTemplate {
   readonly #state: TemplateState;
 
-  private constructor(state: TemplateState) {
+  constructor(state: TemplateState) {
     this.#state = state;
   }
 
-  /** Internal entry used by `Sandbox.template()`. Not reachable by consumers. */
-  static blank(): SandboxTemplate {
-    return new SandboxTemplate(EMPTY_STATE);
-  }
-
-  /** Runs a raw shell command as a build step. */
   run(command: string): SandboxTemplate {
     return this.#append(command);
   }
 
-  /** Installs Debian packages via apt (the base image ships no apt index). */
   withPackages(...packages: string[]): SandboxTemplate {
     if (packages.length === 0) return this;
     return this.#append(
@@ -46,46 +56,37 @@ export class SandboxTemplate {
     );
   }
 
-  /** Sets environment variables folded into every subsequent build step. */
   withEnv(vars: Record<string, string>): SandboxTemplate {
     let env = this.#state.env;
     for (const [key, value] of Object.entries(vars)) {
       env = upsertEnv(env, key, value);
     }
-    return new SandboxTemplate({ ...this.#state, env });
+    return new SandboxTemplateRecipe({ ...this.#state, env });
   }
 
-  /** Sets the working directory for every subsequent build step. */
   workdir(dir: string): SandboxTemplate {
-    return new SandboxTemplate({ ...this.#state, workdir: dir });
+    return new SandboxTemplateRecipe({ ...this.#state, workdir: dir });
   }
 
-  /** Builds the template server-side, resolving only once it is READY. */
   async build(options: TemplateBuildOptions = {}): Promise<SandboxTemplate> {
     const engine = engineFromOptions(options);
-    await engine.buildTemplateUntilReady(this[COMPILE]());
+    await engine.buildTemplateUntilReady(this.compile());
     return this;
   }
 
-  /** @internal compiled instructions, read by `Sandbox.create`. */
-  [COMPILE](): string[] {
+  compile(): string[] {
     return [...this.#state.instructions];
   }
 
   #append(command: string): SandboxTemplate {
     const instruction = compile(command, this.#state.env, this.#state.workdir);
-    return new SandboxTemplate({
+    return new SandboxTemplateRecipe({
       ...this.#state,
       instructions: [...this.#state.instructions, instruction],
     });
   }
 }
 
-/**
- * Folds accumulated env + active workdir into a single instruction. Each
- * instruction is a fresh shell server-side, so exports and `cd` are re-applied
- * per step; the workdir is created (`mkdir -p`) so `cd` always succeeds.
- */
 function compile(
   command: string,
   env: ReadonlyArray<readonly [string, string]>,
@@ -113,7 +114,6 @@ function upsertEnv(
   return next;
 }
 
-/** POSIX single-quote escaping so values with spaces/quotes survive the shell. */
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/src/sandbox/template.ts
+++ b/src/sandbox/template.ts
@@ -14,9 +14,9 @@ const EMPTY_STATE: TemplateState = { instructions: [], env: [] };
 
 /**
  * A fluent, immutable recipe for a server-side sandbox base. Every builder step
- * returns a NEW template — nothing mutates in place — so a base can branch into
- * variants safely. Obtain one with `Sandbox.template()`; it is a pure value and
- * does no network until `build()` or `Sandbox.create(template)`.
+ * returns a new template, so a base can branch into variants safely. Obtain one
+ * with `Sandbox.template()`; it is a pure value and does no network until
+ * `build()` or `Sandbox.create(template)`.
  *
  * Each instruction runs in its own shell server-side, so `env`/`workdir` do not
  * persist between instructions — they are folded into every subsequent command.
@@ -60,7 +60,7 @@ export class SandboxTemplate {
     return new SandboxTemplate({ ...this.#state, workdir: dir });
   }
 
-  /** Builds the template server-side, resolving only once it is READY. Returns itself for chaining. */
+  /** Builds the template server-side, resolving only once it is READY. */
   async build(options: TemplateBuildOptions = {}): Promise<SandboxTemplate> {
     const engine = engineFromOptions(options);
     await engine.buildTemplateUntilReady(this[COMPILE]());

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -2,11 +2,15 @@ import type { RailwayClientConfig } from "../core/config.js";
 import type {
   RailwaySandboxExecMutation,
   RailwaySandboxFieldsFragment,
+  RailwaySandboxTemplateFieldsFragment,
 } from "../generated/graphql.js";
 
 export type SandboxStatus = RailwaySandboxFieldsFragment["status"];
 export type ExecResult = RailwaySandboxExecMutation["sandboxExec"];
 export type SandboxInfo = RailwaySandboxFieldsFragment;
+
+export type SandboxTemplateStatus = RailwaySandboxTemplateFieldsFragment["status"];
+export type SandboxTemplateInfo = RailwaySandboxTemplateFieldsFragment;
 
 export interface CreateOptions extends RailwayClientConfig {
   environmentId?: string;
@@ -25,4 +29,8 @@ export interface ListOptions extends RailwayClientConfig {
 
 export interface ExecOptions {
   timeoutSec?: number;
+}
+
+export interface TemplateBuildOptions extends RailwayClientConfig {
+  environmentId?: string;
 }

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -9,7 +9,6 @@ export type SandboxStatus = RailwaySandboxFieldsFragment["status"];
 export type ExecResult = RailwaySandboxExecMutation["sandboxExec"];
 export type SandboxInfo = RailwaySandboxFieldsFragment;
 
-export type SandboxTemplateStatus = RailwaySandboxTemplateFieldsFragment["status"];
 export type SandboxTemplateInfo = RailwaySandboxTemplateFieldsFragment;
 
 export interface CreateOptions extends RailwayClientConfig {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -36,6 +36,11 @@ async function createWithDestroyMock(): Promise<{
   return { sandbox, calls: mock.calls };
 }
 
+function silenceExpectedRejection<T>(promise: Promise<T>): Promise<T> {
+  promise.catch(() => {});
+  return promise;
+}
+
 describe("Sandbox.create", () => {
   it("creates sandboxes in the configured environment", async () => {
     const mock = createFetchMock([{ data: { sandboxCreate: sandboxInfo() } }]);
@@ -218,8 +223,9 @@ describe("Sandbox.create readiness", () => {
       { data: { sandbox: sandboxInfo({ status: "FAILED" }) } },
     ]);
 
-    const promise = Sandbox.create({ ...auth, fetch: mock.fetch });
-    promise.catch(() => {});
+    const promise = silenceExpectedRejection(
+      Sandbox.create({ ...auth, fetch: mock.fetch }),
+    );
     await vi.advanceTimersByTimeAsync(5 * 60_000);
 
     await expect(promise).rejects.toBeInstanceOf(SandboxFailedError);
@@ -231,8 +237,9 @@ describe("Sandbox.create readiness", () => {
       ...manyResponses(200, { data: { sandbox: sandboxInfo({ status: "CREATING" }) } }),
     ]);
 
-    const promise = Sandbox.create({ ...auth, fetch: mock.fetch });
-    promise.catch(() => {});
+    const promise = silenceExpectedRejection(
+      Sandbox.create({ ...auth, fetch: mock.fetch }),
+    );
     await vi.advanceTimersByTimeAsync(6 * 60_000);
 
     await expect(promise).rejects.toBeInstanceOf(SandboxTimeoutError);
@@ -274,6 +281,9 @@ describe("SandboxTemplate", () => {
 });
 
 describe("SandboxTemplate.build", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it("resolves immediately on a warm template", async () => {
     const mock = createFetchMock([
       { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
@@ -296,62 +306,51 @@ describe("SandboxTemplate.build", () => {
   });
 
   it("polls a cold build until READY", async () => {
-    vi.useFakeTimers();
-    try {
-      const mock = createFetchMock([
-        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
-        { data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) } },
-        { data: { sandboxTemplate: templateInfo({ status: "READY" }) } },
-      ]);
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+      { data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) } },
+      { data: { sandboxTemplate: templateInfo({ status: "READY" }) } },
+    ]);
 
-      const promise = Sandbox.template().run("echo hi").build({ ...auth, fetch: mock.fetch });
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
-      await promise;
+    const promise = Sandbox.template()
+      .run("echo hi")
+      .build({ ...auth, fetch: mock.fetch });
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await promise;
 
-      expect(mock.calls).toHaveLength(3);
-      expect(mock.calls[1]?.body.query).toContain("query RailwaySandboxTemplate");
-      expect(mock.calls[2]?.body.query).toContain("query RailwaySandboxTemplate");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(mock.calls).toHaveLength(3);
+    expect(mock.calls[1]?.body.query).toContain("query RailwaySandboxTemplate");
+    expect(mock.calls[2]?.body.query).toContain("query RailwaySandboxTemplate");
   });
 
   it("throws SandboxTemplateBuildError on FAILED", async () => {
-    vi.useFakeTimers();
-    try {
-      const mock = createFetchMock([
-        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
-        { data: { sandboxTemplate: templateInfo({ status: "FAILED" }) } },
-      ]);
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+      { data: { sandboxTemplate: templateInfo({ status: "FAILED" }) } },
+    ]);
 
-      const promise = Sandbox.template().run("false").build({ ...auth, fetch: mock.fetch });
-      promise.catch(() => {});
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    const promise = silenceExpectedRejection(
+      Sandbox.template().run("false").build({ ...auth, fetch: mock.fetch }),
+    );
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      await expect(promise).rejects.toBeInstanceOf(SandboxTemplateBuildError);
-    } finally {
-      vi.useRealTimers();
-    }
+    await expect(promise).rejects.toBeInstanceOf(SandboxTemplateBuildError);
   });
 
   it("throws SandboxTimeoutError past the ceiling", async () => {
-    vi.useFakeTimers();
-    try {
-      const mock = createFetchMock([
-        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
-        ...manyResponses(200, {
-          data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) },
-        }),
-      ]);
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+      ...manyResponses(200, {
+        data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) },
+      }),
+    ]);
 
-      const promise = Sandbox.template().run("sleep 1").build({ ...auth, fetch: mock.fetch });
-      promise.catch(() => {});
-      await vi.advanceTimersByTimeAsync(6 * 60_000);
+    const promise = silenceExpectedRejection(
+      Sandbox.template().run("sleep 1").build({ ...auth, fetch: mock.fetch }),
+    );
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
 
-      await expect(promise).rejects.toBeInstanceOf(SandboxTimeoutError);
-    } finally {
-      vi.useRealTimers();
-    }
+    await expect(promise).rejects.toBeInstanceOf(SandboxTimeoutError);
   });
 });
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Sandbox, SandboxNotFoundError } from "../src/index.js";
+import {
+  Sandbox,
+  SandboxFailedError,
+  SandboxNotFoundError,
+  SandboxTemplateBuildError,
+  SandboxTimeoutError,
+} from "../src/index.js";
+import { COMPILE } from "../src/sandbox/internal.js";
 import {
   clearRailwayEnv,
   createFetchMock,
+  manyResponses,
   sandboxInfo,
+  templateInfo,
   type FetchCall,
 } from "./test-helpers.js";
 
@@ -100,17 +109,19 @@ describe("sandbox instance", () => {
   });
 
   it("refreshes status in place", async () => {
+    // create resolves at RUNNING (no poll), so the next response is the refresh read.
     const mock = createFetchMock([
-      { data: { sandboxCreate: sandboxInfo({ status: "CREATING" }) } },
-      { data: { sandbox: sandboxInfo({ status: "RUNNING" }) } },
+      { data: { sandboxCreate: sandboxInfo() } },
+      { data: { sandbox: sandboxInfo({ status: "DESTROYING" }) } },
     ]);
 
     const sandbox = await Sandbox.create({ ...auth, fetch: mock.fetch });
-    expect(sandbox.status).toBe("CREATING");
+    expect(sandbox.status).toBe("RUNNING");
 
     await sandbox.refresh();
 
-    expect(sandbox.status).toBe("RUNNING");
+    expect(sandbox.status).toBe("DESTROYING");
+    expect(mock.calls).toHaveLength(2);
     expect(mock.calls[1]?.body.query).toContain("query RailwaySandbox");
     expect(mock.calls[1]?.body.variables).toEqual({
       id: "sandbox_123",
@@ -175,6 +186,199 @@ describe("Sandbox.list", () => {
     expect(mock.calls[0]?.body.variables).toEqual({
       environmentId: "environment_123",
       first: 50,
+    });
+  });
+});
+
+describe("Sandbox.create readiness", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("polls until the sandbox is RUNNING", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxCreate: sandboxInfo({ status: "CREATING" }) } },
+      { data: { sandbox: sandboxInfo({ status: "CREATING" }) } },
+      { data: { sandbox: sandboxInfo({ status: "RUNNING" }) } },
+    ]);
+
+    const promise = Sandbox.create({ ...auth, fetch: mock.fetch });
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    const sandbox = await promise;
+
+    expect(sandbox.status).toBe("RUNNING");
+    expect(mock.calls).toHaveLength(3);
+    expect(mock.calls[0]?.body.query).toContain("mutation RailwaySandboxCreate");
+    expect(mock.calls[1]?.body.query).toContain("query RailwaySandbox");
+    expect(mock.calls[2]?.body.query).toContain("query RailwaySandbox");
+  });
+
+  it("throws SandboxFailedError on a terminal state", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxCreate: sandboxInfo({ status: "CREATING" }) } },
+      { data: { sandbox: sandboxInfo({ status: "FAILED" }) } },
+    ]);
+
+    const promise = Sandbox.create({ ...auth, fetch: mock.fetch });
+    promise.catch(() => {});
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    await expect(promise).rejects.toBeInstanceOf(SandboxFailedError);
+  });
+
+  it("throws SandboxTimeoutError past the ceiling", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxCreate: sandboxInfo({ status: "CREATING" }) } },
+      ...manyResponses(200, { data: { sandbox: sandboxInfo({ status: "CREATING" }) } }),
+    ]);
+
+    const promise = Sandbox.create({ ...auth, fetch: mock.fetch });
+    promise.catch(() => {});
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+
+    await expect(promise).rejects.toBeInstanceOf(SandboxTimeoutError);
+  });
+});
+
+describe("SandboxTemplate", () => {
+  it("builders return new immutable instances", () => {
+    const base = Sandbox.template();
+    const withRun = base.run("echo hi");
+
+    expect(withRun).not.toBe(base);
+    expect(base[COMPILE]()).toEqual([]);
+    expect(withRun[COMPILE]()).toEqual(["echo hi"]);
+  });
+
+  it("folds env + workdir into each subsequent command", () => {
+    const tpl = Sandbox.template()
+      .withEnv({ K: "v" })
+      .workdir("/app")
+      .run("npm install");
+
+    expect(tpl[COMPILE]()).toEqual([
+      "export K='v' && mkdir -p '/app' && cd '/app' && npm install",
+    ]);
+  });
+
+  it("compiles withPackages to an apt install", () => {
+    expect(Sandbox.template().withPackages("ffmpeg", "git")[COMPILE]()).toEqual([
+      "apt-get update && apt-get install -y --no-install-recommends ffmpeg git",
+    ]);
+  });
+
+  it("escapes shell-special env values", () => {
+    expect(
+      Sandbox.template().withEnv({ MSG: "a'b c" }).run("echo $MSG")[COMPILE](),
+    ).toEqual([`export MSG='a'\\''b c' && echo $MSG`]);
+  });
+});
+
+describe("SandboxTemplate.build", () => {
+  it("resolves immediately on a warm template", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
+    ]);
+
+    const base = Sandbox.template().withPackages("ffmpeg");
+    const built = await base.build({ ...auth, fetch: mock.fetch });
+
+    expect(built).toBe(base);
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]?.body.query).toContain("mutation RailwaySandboxTemplateBuild");
+    expect(mock.calls[0]?.body.variables).toEqual({
+      environmentId: "environment_123",
+      input: {
+        instructions: [
+          "apt-get update && apt-get install -y --no-install-recommends ffmpeg",
+        ],
+      },
+    });
+  });
+
+  it("polls a cold build until READY", async () => {
+    vi.useFakeTimers();
+    try {
+      const mock = createFetchMock([
+        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+        { data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) } },
+        { data: { sandboxTemplate: templateInfo({ status: "READY" }) } },
+      ]);
+
+      const promise = Sandbox.template().run("echo hi").build({ ...auth, fetch: mock.fetch });
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await promise;
+
+      expect(mock.calls).toHaveLength(3);
+      expect(mock.calls[1]?.body.query).toContain("query RailwaySandboxTemplate");
+      expect(mock.calls[2]?.body.query).toContain("query RailwaySandboxTemplate");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws SandboxTemplateBuildError on FAILED", async () => {
+    vi.useFakeTimers();
+    try {
+      const mock = createFetchMock([
+        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+        { data: { sandboxTemplate: templateInfo({ status: "FAILED" }) } },
+      ]);
+
+      const promise = Sandbox.template().run("false").build({ ...auth, fetch: mock.fetch });
+      promise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      await expect(promise).rejects.toBeInstanceOf(SandboxTemplateBuildError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws SandboxTimeoutError past the ceiling", async () => {
+    vi.useFakeTimers();
+    try {
+      const mock = createFetchMock([
+        { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
+        ...manyResponses(200, {
+          data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) },
+        }),
+      ]);
+
+      const promise = Sandbox.template().run("sleep 1").build({ ...auth, fetch: mock.fetch });
+      promise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(6 * 60_000);
+
+      await expect(promise).rejects.toBeInstanceOf(SandboxTimeoutError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Sandbox.create(template)", () => {
+  it("builds then forks, resolving at RUNNING", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
+      { data: { sandboxCreate: sandboxInfo() } },
+    ]);
+
+    const base = Sandbox.template().withPackages("ffmpeg").workdir("/app").run("true");
+    const sandbox = await Sandbox.create(base, { ...auth, fetch: mock.fetch });
+
+    expect(sandbox.status).toBe("RUNNING");
+    expect(mock.calls).toHaveLength(2);
+    expect(mock.calls[0]?.body.query).toContain("mutation RailwaySandboxTemplateBuild");
+    expect(mock.calls[1]?.body.query).toContain("mutation RailwaySandboxCreate");
+    expect(mock.calls[1]?.body.variables).toMatchObject({
+      input: {
+        environmentId: "environment_123",
+        template: {
+          instructions: [
+            "apt-get update && apt-get install -y --no-install-recommends ffmpeg",
+            "mkdir -p '/app' && cd '/app' && true",
+          ],
+        },
+      },
     });
   });
 });

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -7,7 +7,7 @@ import {
   SandboxTemplateBuildError,
   SandboxTimeoutError,
 } from "../src/index.js";
-import { COMPILE } from "../src/sandbox/internal.js";
+import { compileSandboxTemplate } from "../src/sandbox/template.js";
 import {
   clearRailwayEnv,
   createFetchMock,
@@ -231,7 +231,7 @@ describe("Sandbox.create readiness", () => {
     await expect(promise).rejects.toBeInstanceOf(SandboxFailedError);
   });
 
-  it("throws SandboxTimeoutError past the ceiling", async () => {
+  it("throws SandboxTimeoutError after the readiness timeout", async () => {
     const mock = createFetchMock([
       { data: { sandboxCreate: sandboxInfo({ status: "CREATING" }) } },
       ...manyResponses(200, { data: { sandbox: sandboxInfo({ status: "CREATING" }) } }),
@@ -252,8 +252,8 @@ describe("SandboxTemplate", () => {
     const withRun = base.run("echo hi");
 
     expect(withRun).not.toBe(base);
-    expect(base[COMPILE]()).toEqual([]);
-    expect(withRun[COMPILE]()).toEqual(["echo hi"]);
+    expect(compileSandboxTemplate(base)).toEqual([]);
+    expect(compileSandboxTemplate(withRun)).toEqual(["echo hi"]);
   });
 
   it("folds env + workdir into each subsequent command", () => {
@@ -262,20 +262,24 @@ describe("SandboxTemplate", () => {
       .workdir("/app")
       .run("npm install");
 
-    expect(tpl[COMPILE]()).toEqual([
+    expect(compileSandboxTemplate(tpl)).toEqual([
       "export K='v' && mkdir -p '/app' && cd '/app' && npm install",
     ]);
   });
 
   it("compiles withPackages to an apt install", () => {
-    expect(Sandbox.template().withPackages("ffmpeg", "git")[COMPILE]()).toEqual([
+    expect(
+      compileSandboxTemplate(Sandbox.template().withPackages("ffmpeg", "git")),
+    ).toEqual([
       "apt-get update && apt-get install -y --no-install-recommends ffmpeg git",
     ]);
   });
 
   it("escapes shell-special env values", () => {
     expect(
-      Sandbox.template().withEnv({ MSG: "a'b c" }).run("echo $MSG")[COMPILE](),
+      compileSandboxTemplate(
+        Sandbox.template().withEnv({ MSG: "a'b c" }).run("echo $MSG"),
+      ),
     ).toEqual([`export MSG='a'\\''b c' && echo $MSG`]);
   });
 });
@@ -284,7 +288,7 @@ describe("SandboxTemplate.build", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it("resolves immediately on a warm template", async () => {
+  it("resolves immediately when the template is already READY", async () => {
     const mock = createFetchMock([
       { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
     ]);
@@ -305,7 +309,7 @@ describe("SandboxTemplate.build", () => {
     });
   });
 
-  it("polls a cold build until READY", async () => {
+  it("polls a template build until READY", async () => {
     const mock = createFetchMock([
       { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
       { data: { sandboxTemplate: templateInfo({ status: "BUILDING" }) } },
@@ -337,7 +341,7 @@ describe("SandboxTemplate.build", () => {
     await expect(promise).rejects.toBeInstanceOf(SandboxTemplateBuildError);
   });
 
-  it("throws SandboxTimeoutError past the ceiling", async () => {
+  it("throws SandboxTimeoutError after the readiness timeout", async () => {
     const mock = createFetchMock([
       { data: { sandboxTemplateBuild: templateInfo({ status: "BUILDING" }) } },
       ...manyResponses(200, {

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 
-import type { SandboxInfo } from "../src/index.js";
+import type { SandboxInfo, SandboxTemplateInfo } from "../src/index.js";
 
 /** Neutralizes ambient RAILWAY_* env vars so tests resolve config deterministically. */
 export function clearRailwayEnv(): void {
@@ -52,6 +52,22 @@ export function sandboxInfo(overrides: Partial<SandboxInfo> = {}): SandboxInfo {
     createdAt: "2026-05-13T00:00:00.000Z",
     ...overrides,
   };
+}
+
+export function templateInfo(
+  overrides: Partial<SandboxTemplateInfo> = {},
+): SandboxTemplateInfo {
+  return {
+    id: "template_123",
+    status: "READY",
+    environmentId: "environment_123",
+    ...overrides,
+  };
+}
+
+/** Repeats a single response `n` times — handy for poll/timeout sequences. */
+export function manyResponses(n: number, response: unknown): unknown[] {
+  return Array.from({ length: n }, () => response);
 }
 
 export function header(init: RequestInit | undefined, name: string): string | null {

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 
-import type { SandboxInfo, SandboxTemplateInfo } from "../src/index.js";
+import type { SandboxInfo } from "../src/index.js";
+import type { SandboxTemplateInfo } from "../src/sandbox/types.js";
 
 /** Neutralizes ambient RAILWAY_* env vars so tests resolve config deterministically. */
 export function clearRailwayEnv(): void {


### PR DESCRIPTION
Adds server-side sandbox templates to the SDK and makes `create()` resolve only once the sandbox is `RUNNING`, polling inside the SDK so the caller never waits.

- `Sandbox.template()` returns a fluent, immutable `SandboxTemplate` (pure value, zero network) with `run`/`withPackages`/`withEnv`/`workdir`/`build`; `Sandbox.create(template)` builds-then-forks
- Each instruction runs in a fresh shell server-side, so `env`/`workdir` fold into every subsequent command; `withPackages` runs `apt-get update` first since the base image ships no apt index
- `template.build()` is idempotent and returns the template; cold builds and warm forks are the same call
- Engine gains one shared poll-with-backoff (5-minute ceiling) for both template->`READY` and sandbox->`RUNNING`
- New errors `SandboxFailedError`, `SandboxTemplateBuildError`, `SandboxTimeoutError`; `SandboxTemplate` is type-only exported with compiled instructions kept internal
- GraphQL `sandboxTemplateBuild` mutation + `sandboxTemplate` query added and codegen regenerated
- Offline tests (fake timers), `example:template`, README + vision docs updated

Verified live against the local dev backend: blank create, template cold build + fork, warm `build()`/fork, ready-on-resolve, and the `FAILED` build error path all work. Package builds with apt currently fail because `apt-get update` fails inside the build (materialize) sandbox while succeeding in runtime sandboxes; that is a backend build-environment issue, not the SDK.