### PR TITLE
feat: send User-Agent header on GraphQL requests

### DIFF
--- a/examples/sandboxes/template.ts
+++ b/examples/sandboxes/template.ts
@@ -2,10 +2,9 @@ import { Sandbox } from "../../src/index.ts";
 import { runExample } from "./helpers.ts";
 
 await runExample(async () => {
-  const base = Sandbox.template().withPackages("ffmpeg").workdir("/app");
+  const base = Sandbox.template().withPackages("cowsay").workdir("/app");
 
   await using sandbox = await Sandbox.create(base);
 
-  console.log((await sandbox.exec("ffmpeg -version")).stdout);
-  console.log((await sandbox.exec("pwd")).stdout);
+  console.log((await sandbox.exec("/usr/games/cowsay hello")).stdout);
 });

--- a/src/core/graphql-client.ts
+++ b/src/core/graphql-client.ts
@@ -6,6 +6,7 @@ import {
   RailwayGraphQLError,
   type RailwayGraphQLErrorItem,
 } from "./errors.js";
+import { USER_AGENT } from "./version.js";
 
 interface GraphQLResponse<TResult> {
   data?: TResult;
@@ -23,6 +24,7 @@ export async function requestGraphQL<TResult, TVariables>(
       Accept: "application/json",
       Authorization: `Bearer ${config.token}`,
       "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
     },
     body: JSON.stringify({
       query: print(document as DocumentNode),

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,10 @@
+// Injected by tsup at build time from package.json; falls back when running
+// unbundled (vitest/tsx).
+declare const __RAILWAY_SDK_VERSION__: string | undefined;
+
+export const SDK_VERSION =
+  typeof __RAILWAY_SDK_VERSION__ !== "undefined"
+    ? __RAILWAY_SDK_VERSION__
+    : "0.0.0-dev";
+
+export const USER_AGENT = `railway-ts-sdk/${SDK_VERSION}`;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsup";
 
+import pkg from "./package.json" with { type: "json" };
+
 export default defineConfig({
   clean: true,
+  define: {
+    __RAILWAY_SDK_VERSION__: JSON.stringify(pkg.version),
+  },
   dts: true,
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],


### PR DESCRIPTION
Sends a `railway-ts-sdk/<version>` User-Agent header on all GraphQL requests, with the version injected at build time.

- Add `src/core/version.ts` exposing `SDK_VERSION`/`USER_AGENT`; version injected via tsup `define`, falling back to `0.0.0-dev` when running unbundled (vitest/tsx)
- Set the `User-Agent` header in `requestGraphQL`
- Switch the template example to cowsay