### PR TITLE
chore: bump version to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "description": "TypeScript SDK for Railway.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` to 3.0.3 to match the `v3.0.3` tag.