### PR TITLE
feat: sandbox env vars (runtime + build-time templates)

### DIFF
--- a/docs/sandbox-sdk-vision.md
+++ b/docs/sandbox-sdk-vision.md
@@ -102,7 +102,38 @@ exception. Reserve exceptions for transport and auth failures.
 
 ---
 
-## 5. Public URLs — Railway's superpower _(future)_
+## 5. Environment variables
+
+Seed a sandbox's environment in one line. Values may be plain strings or Railway
+variable references (`${{shared.FOO}}`, `${{ServiceName.BAR}}`) — resolved
+server-side, so a sandbox can pull a shared secret without you ever handling its
+value.
+
+```ts
+const sandbox = await Sandbox.create({
+  env: { NODE_ENV: "production", API_KEY: "${{shared.API_KEY}}" },
+});
+```
+
+`env` is baked into the sandbox at create time and available to every command it
+runs. It is accepted anywhere a sandbox is created — `Sandbox.create(options)`,
+`Sandbox.create(template, options)`, and `sandbox.fork(options)` (a fork does not
+inherit the source's env, so pass it again).
+
+Runtime env is deliberately separate from a template's build-time env:
+
+| Layer | Set via | Applies to |
+| --- | --- | --- |
+| **Runtime** | `create({ env })` / `fork({ env })` | Every command the created sandbox runs. |
+| **Build-time** | template `.withEnv(…)` (§10) | The template's build instructions only. |
+
+Keeping them separate means a build-only secret (say an `NPM_TOKEN` used by
+`.withEnv(…)` to install private packages) never leaks into the running sandbox's
+environment.
+
+---
+
+## 6. Public URLs — Railway's superpower _(future)_
 
 Public domains are Railway's core competency, so exposing a sandbox port as a real
 HTTPS URL should be a single line — something no other sandbox SDK can make feel as
@@ -124,7 +155,7 @@ is a headline feature. Companion methods grow additively: `sandbox.unexpose(port
 
 ---
 
-## 6. Lifecycle & reconnect
+## 7. Lifecycle & reconnect
 
 A sandbox outlives the process that created it, so you can reattach to it by id — ideal
 for serverless and multi-step agent workflows.
@@ -145,7 +176,7 @@ update `status` and the other fields in place.
 
 ---
 
-## 7. Auto-cleanup with `await using`
+## 8. Auto-cleanup with `await using`
 
 A sandbox is a disposable resource, so it implements `Symbol.asyncDispose`. With
 `await using`, it is destroyed automatically when the scope exits — even on throw — and
@@ -161,7 +192,7 @@ await sandbox.exec("pytest");
 
 ---
 
-## 8. Files _(future)_
+## 9. Files _(future)_
 
 File access lives under a `files` namespace so it never crowds the quickstart. Writes
 accept a string or bytes (no `Buffer` ceremony) and support a batch form, because every
@@ -185,7 +216,7 @@ Planned surface: `read` / `readText` / `write` / `list` / `info` / `exists` /
 
 ---
 
-## 9. Templates: reusable bases
+## 10. Templates: reusable bases
 
 The centerpiece of the vision. You rarely want a blank box — you want _your_
 environment (a runtime, system packages, your code) and you want to stamp sandboxes
@@ -207,8 +238,13 @@ const sandbox = await Sandbox.create(base);
 
 Available today: `.run("…")` (the raw escape hatch), `.withPackages(…)`,
 `.withEnv(…)`, `.workdir(…)`, and `template.build()`. Builds run server-side on the
-default base image, content-addressed and cached. Reserved for later: custom base
-images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
+default base image, content-addressed and cached. `.withEnv(…)` sets **build-time**
+env for the build instructions — resolved (including Railway references) at build
+time and folded into the template's content hash, so templates differing only by
+env build and cache separately; for env in the running sandbox, use
+`create({ env })` (§5). A template with no build steps (e.g. only `.withEnv(…)`) is
+never built server-side — there is nothing to snapshot. Reserved for later: custom
+base images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
 `withPython`, `copy`), and `.toDockerfile()` transparency.
 
 > The types are named `SandboxTemplate` / `SandboxBase` — never a bare `Template` —
@@ -217,7 +253,7 @@ images (`Sandbox.template("node:20")`), more node-first sugar (`withNode`,
 
 ---
 
-## 10. `create(source?)` — one verb, many starting points _(future)_
+## 11. `create(source?)` — one verb, many starting points _(future)_
 
 One verb covers every way to start a sandbox. `create()` with no source is the blank
 box; `create(source)` starts from a reusable base.
@@ -239,7 +275,7 @@ boot, not live processes) into the same environment.
 
 ---
 
-## 11. Streaming & background commands _(future)_
+## 12. Streaming & background commands _(future)_
 
 The plain `exec` call shape never changes. Streaming and background execution arrive as
 options that return richer — but still awaitable — handles, so the simple case stays a
@@ -265,7 +301,7 @@ types. We use async iterators over callbacks because they compose with `for awai
 
 ---
 
-## 12. Errors
+## 13. Errors
 
 All SDK errors extend `RailwayError`:
 
@@ -281,7 +317,7 @@ All SDK errors extend `RailwayError`:
 
 ---
 
-## 13. Backend phasing
+## 14. Backend phasing
 
 Honesty about what is real. Every future surface is designed to its final signature so
 that shipping it flips on a network call — never a breaking type change.
@@ -294,6 +330,8 @@ that shipping it flips on a network call — never a breaking type change.
 | Env-resolved config + `RailwayAuthError` | **Live** |
 | `Sandbox.connect(id)` / `Sandbox.list()` / `sandbox.refresh()` | **Live** |
 | `create({ networkIsolation })` + `sandbox.networkIsolation` | **Live** |
+| `create({ env })` / `fork({ env })` runtime variables | **Live** |
+| Template `.withEnv(…)` build-time variables | **Live** |
 | `sandbox.files.*` | Future |
 | `Sandbox.template()` / `SandboxTemplate` / `create(template)` | **Live** |
 | `sandbox.fork()` / `create(sandbox)` | **Live** |
@@ -304,7 +342,7 @@ that shipping it flips on a network call — never a breaking type change.
 
 ---
 
-## 14. API reference (today)
+## 15. API reference (today)
 
 ```ts
 import {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -5464,6 +5464,8 @@ export type SandboxCreateInput = {
   /** Fork an existing running sandbox in this environment. Mutually exclusive with template. */
   sourceSandboxId?: InputMaybe<Scalars['String']['input']>;
   template?: InputMaybe<SandboxTemplateInput>;
+  /** Environment variables baked into the sandbox, available to every command. Values may contain Railway variable references (e.g. ${{shared.FOO}}, ${{ServiceName.BAR}}), resolved at create time. */
+  variables?: InputMaybe<Scalars['EnvironmentVariables']['input']>;
 };
 
 export type SandboxExecResult = {
@@ -5499,6 +5501,8 @@ export type SandboxTemplate = {
 export type SandboxTemplateInput = {
   baseImageDigest?: InputMaybe<Scalars['String']['input']>;
   instructions: Array<Scalars['String']['input']>;
+  /** Environment variables available to the template's build instructions. Values may contain Railway variable references (e.g. ${{shared.FOO}}, ${{ServiceName.BAR}}), resolved at build time. */
+  variables?: InputMaybe<Scalars['EnvironmentVariables']['input']>;
 };
 
 export type SandboxTemplateStatus =

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -35,6 +35,7 @@ import {
   SandboxTimeoutError,
 } from "./errors.js";
 import type {
+  CompiledTemplate,
   CreateOptions,
   ExecOptions,
   ExecResult,
@@ -76,13 +77,18 @@ export class SandboxEngine {
 
   async create(
     options: CreateOptions = {},
-    templateInstructions?: readonly string[],
+    template?: CompiledTemplate,
   ): Promise<SandboxInfo> {
     const input: RailwaySandboxCreateMutationVariables["input"] = {
       environmentId: this.#config.environmentId,
     };
-    if (templateInstructions !== undefined) {
-      input.template = { instructions: [...templateInstructions] };
+    if (template !== undefined) {
+      // Echo the template's build-time variables so the backend hash matches
+      // the built snapshot and forks from it.
+      input.template = {
+        instructions: [...template.instructions],
+        ...(template.variables && { variables: template.variables }),
+      };
     }
 
     return this.#createAndWait(input, options);
@@ -109,6 +115,9 @@ export class SandboxEngine {
     if (options.networkIsolation !== undefined) {
       input.networkIsolation = options.networkIsolation;
     }
+    if (options.env !== undefined) {
+      input.variables = options.env;
+    }
 
     const data = await requestGraphQL<
       RailwaySandboxCreateMutation,
@@ -118,12 +127,15 @@ export class SandboxEngine {
     return this.#waitForRunning(data.sandboxCreate);
   }
 
-  async buildTemplate(
-    instructions: readonly string[],
-  ): Promise<SandboxTemplateInfo> {
+  async buildTemplate(template: CompiledTemplate): Promise<SandboxTemplateInfo> {
+    const input: RailwaySandboxTemplateBuildMutationVariables["input"] = {
+      instructions: [...template.instructions],
+    };
+    if (template.variables) input.variables = template.variables;
+
     const variables: RailwaySandboxTemplateBuildMutationVariables = {
       environmentId: this.#config.environmentId,
-      input: { instructions: [...instructions] },
+      input,
     };
     const data = await requestGraphQL<
       RailwaySandboxTemplateBuildMutation,
@@ -147,9 +159,9 @@ export class SandboxEngine {
   }
 
   async buildTemplateUntilReady(
-    instructions: readonly string[],
+    template: CompiledTemplate,
   ): Promise<SandboxTemplateInfo> {
-    const built = await this.buildTemplate(instructions);
+    const built = await this.buildTemplate(template);
     if (built.status === "READY") return built;
     if (built.status === "FAILED") {
       throw new SandboxTemplateBuildError({

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -27,6 +27,7 @@ import {
   type RailwaySandboxTemplateBuildMutationVariables,
   type RailwaySandboxTemplateQuery,
   type RailwaySandboxTemplateQueryVariables,
+  type SandboxTemplateInput,
 } from "../generated/graphql.js";
 import {
   SandboxFailedError,
@@ -85,10 +86,7 @@ export class SandboxEngine {
     if (template !== undefined) {
       // Echo the template's build-time variables so the backend hash matches
       // the built snapshot and forks from it.
-      input.template = {
-        instructions: [...template.instructions],
-        ...(template.variables && { variables: template.variables }),
-      };
+      input.template = toTemplateInput(template);
     }
 
     return this.#createAndWait(input, options);
@@ -128,14 +126,9 @@ export class SandboxEngine {
   }
 
   async buildTemplate(template: CompiledTemplate): Promise<SandboxTemplateInfo> {
-    const input: RailwaySandboxTemplateBuildMutationVariables["input"] = {
-      instructions: [...template.instructions],
-    };
-    if (template.variables) input.variables = template.variables;
-
     const variables: RailwaySandboxTemplateBuildMutationVariables = {
       environmentId: this.#config.environmentId,
-      input,
+      input: toTemplateInput(template),
     };
     const data = await requestGraphQL<
       RailwaySandboxTemplateBuildMutation,
@@ -305,6 +298,13 @@ export class SandboxEngine {
 
 function isSandboxTerminal(status: SandboxInfo["status"]): boolean {
   return status === "FAILED" || status === "DESTROYED" || status === "DESTROYING";
+}
+
+function toTemplateInput(template: CompiledTemplate): SandboxTemplateInput {
+  return {
+    instructions: [...template.instructions],
+    ...(template.variables && { variables: template.variables }),
+  };
 }
 
 export function engineFromOptions(options: SandboxOptions = {}): SandboxEngine {

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -86,9 +86,14 @@ export class Sandbox implements AsyncDisposable {
 
     if (isSandboxTemplate(sourceOrOptions)) {
       const engine = engineFromOptions(maybeOptions);
-      const instructions = compileSandboxTemplate(sourceOrOptions);
-      await engine.buildTemplateUntilReady(instructions);
-      const info = await engine.create(maybeOptions, instructions);
+      const compiled = compileSandboxTemplate(sourceOrOptions);
+      if (compiled.instructions.length === 0) {
+        // No build steps → nothing to build. Build-time variables have no
+        // effect; runtime env still comes from `create({ env })`.
+        return new Sandbox(engine, await engine.create(maybeOptions));
+      }
+      await engine.buildTemplateUntilReady(compiled);
+      const info = await engine.create(maybeOptions, compiled);
       return new Sandbox(engine, info);
     }
 

--- a/src/sandbox/template.ts
+++ b/src/sandbox/template.ts
@@ -1,5 +1,5 @@
 import { engineFromOptions } from "./engine.js";
-import type { TemplateBuildOptions } from "./types.js";
+import type { CompiledTemplate, TemplateBuildOptions } from "./types.js";
 
 interface TemplateState {
   readonly instructions: readonly string[];
@@ -15,7 +15,11 @@ export interface SandboxTemplate {
   run(command: string): SandboxTemplate;
   /** Install Debian packages with apt. */
   withPackages(...packages: string[]): SandboxTemplate;
-  /** Set environment variables for later build steps. */
+  /**
+   * Set build-time environment variables available to the build instructions.
+   * Values may use Railway references (e.g. `${{shared.FOO}}`), resolved at
+   * build time. Build-time only — runtime env comes from `create({ env })`.
+   */
   withEnv(vars: Record<string, string>): SandboxTemplate;
   /** Set the working directory for later build steps. */
   workdir(dir: string): SandboxTemplate;
@@ -31,7 +35,9 @@ export function isSandboxTemplate(value: unknown): value is SandboxTemplate {
   return value instanceof SandboxTemplateRecipe;
 }
 
-export function compileSandboxTemplate(template: SandboxTemplate): string[] {
+export function compileSandboxTemplate(
+  template: SandboxTemplate,
+): CompiledTemplate {
   if (!(template instanceof SandboxTemplateRecipe)) {
     throw new TypeError("Expected a SandboxTemplate returned by Sandbox.template().");
   }
@@ -69,17 +75,22 @@ class SandboxTemplateRecipe implements SandboxTemplate {
   }
 
   async build(options: TemplateBuildOptions = {}): Promise<SandboxTemplate> {
-    const engine = engineFromOptions(options);
-    await engine.buildTemplateUntilReady(this.compile());
+    const compiled = this.compile();
+    // Nothing to build without instructions; build-time env alone has no effect.
+    if (compiled.instructions.length > 0) {
+      await engineFromOptions(options).buildTemplateUntilReady(compiled);
+    }
     return this;
   }
 
-  compile(): string[] {
-    return [...this.#state.instructions];
+  compile(): CompiledTemplate {
+    const instructions = [...this.#state.instructions];
+    if (this.#state.env.length === 0) return { instructions };
+    return { instructions, variables: Object.fromEntries(this.#state.env) };
   }
 
   #append(command: string): SandboxTemplate {
-    const instruction = compile(command, this.#state.env, this.#state.workdir);
+    const instruction = compileInstruction(command, this.#state.workdir);
     return new SandboxTemplateRecipe({
       ...this.#state,
       instructions: [...this.#state.instructions, instruction],
@@ -87,19 +98,10 @@ class SandboxTemplateRecipe implements SandboxTemplate {
   }
 }
 
-function compile(
-  command: string,
-  env: ReadonlyArray<readonly [string, string]>,
-  workdir: string | undefined,
-): string {
-  const parts: string[] = [];
-  for (const [key, value] of env) parts.push(`export ${key}=${shellQuote(value)}`);
-  if (workdir !== undefined) {
-    const quoted = shellQuote(workdir);
-    parts.push(`mkdir -p ${quoted}`, `cd ${quoted}`);
-  }
-  parts.push(command);
-  return parts.join(" && ");
+function compileInstruction(command: string, workdir: string | undefined): string {
+  if (workdir === undefined) return command;
+  const quoted = shellQuote(workdir);
+  return `mkdir -p ${quoted} && cd ${quoted} && ${command}`;
 }
 
 function upsertEnv(

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -13,10 +13,19 @@ export type SandboxInfo = RailwaySandboxFieldsFragment;
 
 export type SandboxTemplateInfo = RailwaySandboxTemplateFieldsFragment;
 
+/** A template recipe compiled into the inputs the backend understands. */
+export interface CompiledTemplate {
+  readonly instructions: readonly string[];
+  /** Build-time env for the build instructions; omitted when empty. */
+  readonly variables?: Record<string, string>;
+}
+
 /** Knobs shared by every sandbox-creating call: `create`, `create(template)`, and `fork`. */
 export interface SandboxCreationOptions {
   idleTimeoutMinutes?: number;
   networkIsolation?: SandboxNetworkIsolation;
+  /** Runtime env baked into the sandbox, available to every command. Values may use Railway references (e.g. `${{shared.FOO}}`). */
+  env?: Record<string, string>;
 }
 
 export interface CreateOptions

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -92,6 +92,23 @@ describe("Sandbox.create", () => {
       input: { environmentId: "environment_123", networkIsolation: "PRIVATE" },
     });
   });
+
+  it("passes env (incl. Railway references) into the create input verbatim", async () => {
+    const mock = createFetchMock([{ data: { sandboxCreate: sandboxInfo() } }]);
+
+    await Sandbox.create({
+      ...auth,
+      env: { NODE_ENV: "production", API_KEY: "${{shared.API_KEY}}" },
+      fetch: mock.fetch,
+    });
+
+    expect(mock.calls[0]?.body.variables).toEqual({
+      input: {
+        environmentId: "environment_123",
+        variables: { NODE_ENV: "production", API_KEY: "${{shared.API_KEY}}" },
+      },
+    });
+  });
 });
 
 describe("sandbox instance", () => {
@@ -282,35 +299,38 @@ describe("SandboxTemplate", () => {
     const withRun = base.run("echo hi");
 
     expect(withRun).not.toBe(base);
-    expect(compileSandboxTemplate(base)).toEqual([]);
-    expect(compileSandboxTemplate(withRun)).toEqual(["echo hi"]);
+    expect(compileSandboxTemplate(base)).toEqual({ instructions: [] });
+    expect(compileSandboxTemplate(withRun)).toEqual({ instructions: ["echo hi"] });
   });
 
-  it("folds env + workdir into each subsequent command", () => {
+  it("folds workdir into each subsequent command, keeping env as build-time variables", () => {
     const tpl = Sandbox.template()
       .withEnv({ K: "v" })
       .workdir("/app")
       .run("npm install");
 
-    expect(compileSandboxTemplate(tpl)).toEqual([
-      "export K='v' && mkdir -p '/app' && cd '/app' && npm install",
-    ]);
+    expect(compileSandboxTemplate(tpl)).toEqual({
+      instructions: ["mkdir -p '/app' && cd '/app' && npm install"],
+      variables: { K: "v" },
+    });
   });
 
   it("compiles withPackages to an apt install", () => {
     expect(
       compileSandboxTemplate(Sandbox.template().withPackages("ffmpeg", "git")),
-    ).toEqual([
-      "apt-get update && apt-get install -y --no-install-recommends ffmpeg git",
-    ]);
+    ).toEqual({
+      instructions: [
+        "apt-get update && apt-get install -y --no-install-recommends ffmpeg git",
+      ],
+    });
   });
 
-  it("escapes shell-special env values", () => {
+  it("passes env values through raw as build-time variables (no shell escaping)", () => {
     expect(
       compileSandboxTemplate(
         Sandbox.template().withEnv({ MSG: "a'b c" }).run("echo $MSG"),
       ),
-    ).toEqual([`export MSG='a'\\''b c' && echo $MSG`]);
+    ).toEqual({ instructions: ["echo $MSG"], variables: { MSG: "a'b c" } });
   });
 });
 
@@ -337,6 +357,32 @@ describe("SandboxTemplate.build", () => {
         ],
       },
     });
+  });
+
+  it("passes withEnv through as build-time variables", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
+    ]);
+
+    await Sandbox.template()
+      .withEnv({ FOO: "bar" })
+      .run("echo hi")
+      .build({ ...auth, fetch: mock.fetch });
+
+    expect(mock.calls[0]?.body.variables).toEqual({
+      environmentId: "environment_123",
+      input: { instructions: ["echo hi"], variables: { FOO: "bar" } },
+    });
+  });
+
+  it("skips the backend build when there are no instructions", async () => {
+    const mock = createFetchMock([]);
+
+    const base = Sandbox.template().withEnv({ FOO: "bar" });
+    const built = await base.build({ ...auth, fetch: mock.fetch });
+
+    expect(built).toBe(base);
+    expect(mock.calls).toHaveLength(0);
   });
 
   it("polls a template build until READY", async () => {
@@ -414,6 +460,42 @@ describe("Sandbox.create(template)", () => {
       },
     });
   });
+
+  it("echoes build-time variables into both the build and the create template input", async () => {
+    const mock = createFetchMock([
+      { data: { sandboxTemplateBuild: templateInfo({ status: "READY" }) } },
+      { data: { sandboxCreate: sandboxInfo() } },
+    ]);
+
+    const base = Sandbox.template().withEnv({ FOO: "bar" }).run("true");
+    await Sandbox.create(base, { ...auth, fetch: mock.fetch });
+
+    expect(mock.calls[0]?.body.variables).toEqual({
+      environmentId: "environment_123",
+      input: { instructions: ["true"], variables: { FOO: "bar" } },
+    });
+    expect(mock.calls[1]?.body.variables).toEqual({
+      input: {
+        environmentId: "environment_123",
+        template: { instructions: ["true"], variables: { FOO: "bar" } },
+      },
+    });
+  });
+
+  it("skips the build for an env-only template, creating directly", async () => {
+    const mock = createFetchMock([{ data: { sandboxCreate: sandboxInfo() } }]);
+
+    const base = Sandbox.template().withEnv({ FOO: "bar" });
+    const sandbox = await Sandbox.create(base, { ...auth, fetch: mock.fetch });
+
+    expect(sandbox.status).toBe("RUNNING");
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]?.body.query).toContain("mutation RailwaySandboxCreate");
+    // Build-time env with no build steps has no effect and isn't sent.
+    expect(mock.calls[0]?.body.variables).toEqual({
+      input: { environmentId: "environment_123" },
+    });
+  });
 });
 
 const forkResponse = { data: { sandboxCreate: sandboxInfo({ id: "forked_123" }) } };
@@ -450,6 +532,19 @@ describe("sandbox.fork", () => {
         environmentId: "environment_123",
         sourceSandboxId: "sandbox_123",
         networkIsolation: "PRIVATE",
+      },
+    });
+  });
+
+  it("passes env into the fork input as runtime variables", async () => {
+    const { sandbox, calls } = await createThenQueue(forkResponse);
+    await sandbox.fork({ env: { FOO: "bar" } });
+
+    expect(calls[1]?.body.variables).toEqual({
+      input: {
+        environmentId: "environment_123",
+        sourceSandboxId: "sandbox_123",
+        variables: { FOO: "bar" },
       },
     });
   });


### PR DESCRIPTION
Adds sandbox environment variable support, backed by railwayapp/mono#30635 (runtime) and #30653 (build-time).

- Runtime `env` option on `Sandbox.create`, `create(template)`, and `fork`, mapped to `SandboxCreateInput.variables`; values may use Railway references (`${{shared.FOO}}`), resolved server-side.
- Template `.withEnv()` now compiles to structural `SandboxTemplateInput.variables` (build-time, references resolved at build, folded into the template snapshot hash) instead of `export K=v` shell prefixes.
- Templates with no build steps skip the backend build entirely.
- Regenerated GraphQL types scoped to the two new `variables` fields; unit tests and vision-doc updates.