### PR TITLE
Add verbose logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,20 +187,6 @@ Set `verbose: true` (or `RAILWAY_VERBOSE=1`) to print human-readable progress to
 GraphQL requests, readiness polling, and lifecycle events. Useful when a `create`, `fork`, or
 template build seems stuck. Tokens and `env` values are never logged.
 
-```ts
-const sandbox = await Sandbox.create({ verbose: true });
-// [railway] create env=… idleTimeout=none network=default envKeys=[]
-// [railway] → RailwaySandboxCreate POST https://backboard.railway.com/graphql/v2
-// [railway] ← RailwaySandboxCreate ok in 142ms
-// [railway] created sandbox sandbox_… status=BUILDING
-// [railway] waiting on sandbox sandbox_… status=BUILDING, retry in 1000ms (elapsed 0.5s)
-// [railway] sandbox sandbox_… status=RUNNING ready after 3.2s
-```
-
-```sh
-RAILWAY_VERBOSE=1 node my-script.js
-```
-
 ## Errors
 
 All errors extend `RailwayError`:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ then an environment variable, then a default. Pass explicit values to override.
 | `environmentId` | `RAILWAY_ENVIRONMENT_ID` | _(required)_ |
 | `endpoint` | `RAILWAY_GRAPHQL_ENDPOINT` | `https://backboard.railway.com/graphql/v2` |
 | `fetch` | n/a | `globalThis.fetch` |
+| `verbose` | `RAILWAY_VERBOSE` | `false` |
 
 ```ts
 const sandbox = await Sandbox.create({
@@ -179,6 +180,26 @@ const sandbox = await Sandbox.create({
 
 Environment variables are read only where a runtime exposes them, so the SDK is safe to
 import in the browser and edge runtimes; provide credentials explicitly there.
+
+### Verbose logging
+
+Set `verbose: true` (or `RAILWAY_VERBOSE=1`) to print human-readable progress to **stderr** —
+GraphQL requests, readiness polling, and lifecycle events. Useful when a `create`, `fork`, or
+template build seems stuck. Tokens and `env` values are never logged.
+
+```ts
+const sandbox = await Sandbox.create({ verbose: true });
+// [railway] create env=… idleTimeout=none network=default envKeys=[]
+// [railway] → RailwaySandboxCreate POST https://backboard.railway.com/graphql/v2
+// [railway] ← RailwaySandboxCreate ok in 142ms
+// [railway] created sandbox sandbox_… status=BUILDING
+// [railway] waiting on sandbox sandbox_… status=BUILDING, retry in 1000ms (elapsed 0.5s)
+// [railway] sandbox sandbox_… status=RUNNING ready after 3.2s
+```
+
+```sh
+RAILWAY_VERBOSE=1 node my-script.js
+```
 
 ## Errors
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,5 @@
 import { RailwayAuthError } from "./errors.js";
+import { createLogger, type Logger } from "./logger.js";
 
 export const DEFAULT_RAILWAY_GRAPHQL_ENDPOINT =
   "https://backboard.railway.com/graphql/v2";
@@ -6,6 +7,7 @@ export const DEFAULT_RAILWAY_GRAPHQL_ENDPOINT =
 const RAILWAY_TOKEN_ENV = "RAILWAY_API_TOKEN";
 const RAILWAY_ENVIRONMENT_ENV = "RAILWAY_ENVIRONMENT_ID";
 const RAILWAY_ENDPOINT_ENV = "RAILWAY_GRAPHQL_ENDPOINT";
+const RAILWAY_VERBOSE_ENV = "RAILWAY_VERBOSE";
 
 export type RailwayAuthType = "bearer" | "project-token";
 
@@ -16,6 +18,11 @@ export interface RailwayClientConfig {
   /** Alias used by IaC flows. Prefer endpoint for the stable SDK surface. */
   graphqlEndpoint?: string;
   fetch?: typeof fetch;
+  /**
+   * Print human-readable progress to stderr (requests, polling, lifecycle).
+   * Also enabled by `RAILWAY_VERBOSE`. Tokens and env values are never logged.
+   */
+  verbose?: boolean;
 }
 
 export interface NormalizedRailwayClientConfig {
@@ -23,6 +30,7 @@ export interface NormalizedRailwayClientConfig {
   authType: RailwayAuthType;
   endpoint: string;
   fetch: typeof fetch;
+  log: Logger;
 }
 
 /**
@@ -48,12 +56,18 @@ export function normalizeRailwayClientConfig(
       readEnv(RAILWAY_ENDPOINT_ENV),
     ) ?? DEFAULT_RAILWAY_GRAPHQL_ENDPOINT;
 
-  return {
+  const verbose = config.verbose ?? isTruthyEnv(readEnv(RAILWAY_VERBOSE_ENV));
+  const normalized: NormalizedRailwayClientConfig = {
     token,
     authType: config.authType ?? "bearer",
     endpoint,
     fetch: fetchImpl,
+    log: createLogger(verbose),
   };
+  normalized.log(
+    `config resolved: endpoint=${endpoint} authType=${normalized.authType}`,
+  );
+  return normalized;
 }
 
 export function resolveEnvironmentId(explicit?: string): string {
@@ -72,6 +86,13 @@ export function resolveEnvironmentId(explicit?: string): string {
 function readEnv(name: string): string | undefined {
   if (typeof process === "undefined") return undefined;
   return process.env?.[name];
+}
+
+/** Treats `1`/`true`/`yes` as on so `RAILWAY_VERBOSE=0` doesn't accidentally enable. */
+function isTruthyEnv(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {

--- a/src/core/graphql-client.ts
+++ b/src/core/graphql-client.ts
@@ -1,5 +1,5 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
-import { print, type DocumentNode } from "graphql";
+import { Kind, print, type DocumentNode } from "graphql";
 
 import type { NormalizedRailwayClientConfig } from "./config.js";
 import {
@@ -18,6 +18,10 @@ export async function requestGraphQL<TResult, TVariables>(
   document: TypedDocumentNode<TResult, TVariables>,
   variables: TVariables,
 ): Promise<TResult> {
+  const operation = operationName(document as DocumentNode);
+  const start = Date.now();
+  config.log(`→ ${operation} POST ${config.endpoint}`);
+
   const response = await config.fetch(config.endpoint, {
     method: "POST",
     headers: {
@@ -34,8 +38,12 @@ export async function requestGraphQL<TResult, TVariables>(
 
   const body = await parseGraphQLResponse<TResult>(response);
   const errors = body?.errors ?? [];
+  const elapsed = Date.now() - start;
 
   if (!response.ok || errors.length > 0) {
+    config.log(
+      `← ${operation} failed http=${response.status} errors=${errors.length} in ${elapsed}ms`,
+    );
     throw new RailwayGraphQLError({
       message:
         errors[0]?.message ??
@@ -47,6 +55,7 @@ export async function requestGraphQL<TResult, TVariables>(
   }
 
   if (!body?.data) {
+    config.log(`← ${operation} returned no data`);
     throw new RailwayGraphQLError({
       message: "Railway GraphQL response did not include data.",
       status: response.status,
@@ -54,7 +63,17 @@ export async function requestGraphQL<TResult, TVariables>(
     });
   }
 
+  config.log(`← ${operation} ok in ${elapsed}ms`);
   return body.data;
+}
+
+function operationName(document: DocumentNode): string {
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.OPERATION_DEFINITION) {
+      return definition.name?.value ?? "anonymous";
+    }
+  }
+  return "operation";
 }
 
 function authHeader(config: NormalizedRailwayClientConfig): Record<string, string> {

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,17 @@
+/**
+ * Opt-in verbose logging. A no-op unless enabled, so call sites stay
+ * branch-free: `config.log(...)` does nothing when verbose is off.
+ */
+export type Logger = (message: string) => void;
+
+const NOOP: Logger = () => {};
+
+/**
+ * Returns a logger that writes `[railway] <message>` lines to stderr, or a
+ * no-op when `verbose` is false. `console.error` exists in Node, browsers, and
+ * edge runtimes, so this is safe to call anywhere.
+ */
+export function createLogger(verbose: boolean): Logger {
+  if (!verbose) return NOOP;
+  return message => console.error(`[railway] ${message}`);
+}

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -242,13 +242,13 @@ export class SandboxEngine {
     describe?: (value: T) => string;
   }): Promise<T> {
     const start = Date.now();
+    const describe = args.describe;
     let delay = POLL_INITIAL_DELAY_MS;
     let last: T;
     do {
       await sleep(delay);
       last = await args.poll();
       const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
-      const describe = args.describe;
       if (args.isReady(last)) {
         if (describe) this.#config.log(`${describe(last)} ready after ${elapsedSec}s`);
         return last;
@@ -264,9 +264,9 @@ export class SandboxEngine {
         );
       }
     } while (Date.now() - start < READINESS_TIMEOUT_MS);
-    if (args.describe) {
+    if (describe) {
       const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
-      this.#config.log(`${args.describe(last)} timed out after ${elapsedSec}s`);
+      this.#config.log(`${describe(last)} timed out after ${elapsedSec}s`);
     }
     return args.onTimeout(last);
   }

--- a/src/sandbox/engine.ts
+++ b/src/sandbox/engine.ts
@@ -117,10 +117,16 @@ export class SandboxEngine {
       input.variables = options.env;
     }
 
+    this.#config.log(creationLine(input));
+
     const data = await requestGraphQL<
       RailwaySandboxCreateMutation,
       RailwaySandboxCreateMutationVariables
     >(this.#config, RailwaySandboxCreateDocument, { input });
+
+    this.#config.log(
+      `created sandbox ${data.sandboxCreate.id} status=${data.sandboxCreate.status}`,
+    );
 
     return this.#waitForRunning(data.sandboxCreate);
   }
@@ -154,8 +160,17 @@ export class SandboxEngine {
   async buildTemplateUntilReady(
     template: CompiledTemplate,
   ): Promise<SandboxTemplateInfo> {
+    const varCount = template.variables
+      ? Object.keys(template.variables).length
+      : 0;
+    this.#config.log(
+      `build template (${template.instructions.length} steps, vars=${varCount})`,
+    );
     const built = await this.buildTemplate(template);
-    if (built.status === "READY") return built;
+    if (built.status === "READY") {
+      this.#config.log(`template ${built.id} ready (cached)`);
+      return built;
+    }
     if (built.status === "FAILED") {
       throw new SandboxTemplateBuildError({
         templateId: built.id,
@@ -167,6 +182,7 @@ export class SandboxEngine {
       poll: () => this.getTemplate(built.id),
       isReady: template => template.status === "READY",
       isTerminal: template => template.status === "FAILED",
+      describe: template => `template ${template.id} status=${template.status}`,
       onTerminal: template => {
         throw new SandboxTemplateBuildError({
           templateId: template.id,
@@ -194,6 +210,7 @@ export class SandboxEngine {
       poll: () => this.#getOrThrow(created.id),
       isReady: info => info.status === "RUNNING",
       isTerminal: info => isSandboxTerminal(info.status),
+      describe: info => `sandbox ${info.id} status=${info.status}`,
       onTerminal: info => {
         throw new SandboxFailedError({ id: info.id, status: info.status });
       },
@@ -222,6 +239,7 @@ export class SandboxEngine {
     isTerminal: (value: T) => boolean;
     onTerminal: (value: T) => never;
     onTimeout: (value: T) => never;
+    describe?: (value: T) => string;
   }): Promise<T> {
     const start = Date.now();
     let delay = POLL_INITIAL_DELAY_MS;
@@ -229,10 +247,27 @@ export class SandboxEngine {
     do {
       await sleep(delay);
       last = await args.poll();
-      if (args.isReady(last)) return last;
-      if (args.isTerminal(last)) return args.onTerminal(last);
+      const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
+      const describe = args.describe;
+      if (args.isReady(last)) {
+        if (describe) this.#config.log(`${describe(last)} ready after ${elapsedSec}s`);
+        return last;
+      }
+      if (args.isTerminal(last)) {
+        if (describe) this.#config.log(`${describe(last)} hit terminal state`);
+        return args.onTerminal(last);
+      }
       delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
+      if (describe) {
+        this.#config.log(
+          `waiting on ${describe(last)}, retry in ${delay}ms (elapsed ${elapsedSec}s)`,
+        );
+      }
     } while (Date.now() - start < READINESS_TIMEOUT_MS);
+    if (args.describe) {
+      const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
+      this.#config.log(`${args.describe(last)} timed out after ${elapsedSec}s`);
+    }
     return args.onTimeout(last);
   }
 
@@ -248,12 +283,21 @@ export class SandboxEngine {
     };
     if (options.timeoutSec !== undefined) variables.timeoutSec = options.timeoutSec;
 
+    this.#config.log(
+      `exec ${id}: ${truncate(command, 80)} timeout=${options.timeoutSec ?? "none"}`,
+    );
+
     const data = await requestGraphQL<
       RailwaySandboxExecMutation,
       RailwaySandboxExecMutationVariables
     >(this.#config, RailwaySandboxExecDocument, variables);
 
-    return data.sandboxExec;
+    const result = data.sandboxExec;
+    this.#config.log(
+      `exec ${id} done exit=${result.exitCode} timedOut=${result.timedOut} (stdout ${result.stdout.length}b / stderr ${result.stderr.length}b)`,
+    );
+
+    return result;
   }
 
   async destroy(id: string): Promise<void> {
@@ -261,6 +305,7 @@ export class SandboxEngine {
       id,
       environmentId: this.#config.environmentId,
     };
+    this.#config.log(`destroy sandbox ${id}`);
     await requestGraphQL<
       RailwaySandboxDestroyMutation,
       RailwaySandboxDestroyMutationVariables
@@ -277,7 +322,11 @@ export class SandboxEngine {
       RailwaySandboxQueryVariables
     >(this.#config, RailwaySandboxDocument, variables);
 
-    return data.sandbox ?? null;
+    const info = data.sandbox ?? null;
+    if (!info) {
+      this.#config.log(`sandbox ${id} not found (env=${this.environmentId})`);
+    }
+    return info;
   }
 
   async list(options: ListOptions = {}): Promise<SandboxInfo[]> {
@@ -305,6 +354,31 @@ function toTemplateInput(template: CompiledTemplate): SandboxTemplateInput {
     instructions: [...template.instructions],
     ...(template.variables && { variables: template.variables }),
   };
+}
+
+/** Verbose line for a create/fork/template create. Logs env key names, never values. */
+function creationLine(
+  input: RailwaySandboxCreateMutationVariables["input"],
+): string {
+  const kind = input.sourceSandboxId
+    ? "fork"
+    : input.template
+      ? "create-from-template"
+      : "create";
+  const envKeys = input.variables ? Object.keys(input.variables) : [];
+  const parts = [
+    kind,
+    `env=${input.environmentId}`,
+    `idleTimeout=${input.idleTimeoutMinutes ?? "none"}`,
+    `network=${input.networkIsolation ?? "default"}`,
+    `envKeys=[${envKeys.join(",")}]`,
+  ];
+  if (input.sourceSandboxId) parts.push(`source=${input.sourceSandboxId}`);
+  return parts.join(" ");
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}…`;
 }
 
 export function engineFromOptions(options: SandboxOptions = {}): SandboxEngine {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,6 +5,7 @@ import {
   RailwayAuthError,
   RailwayGraphQLError,
   Sandbox,
+  type CreateOptions,
 } from "../src/index.js";
 import {
   clearRailwayEnv,
@@ -117,5 +118,70 @@ describe("configuration", () => {
 
     expect(error).toBeInstanceOf(RailwayGraphQLError);
     expect(error).toMatchObject({ message: "no access" });
+  });
+});
+
+describe("verbose logging", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    stderr.mockRestore();
+  });
+
+  const logged = (): string[] =>
+    stderr.mock.calls.map(call => String(call[0]));
+
+  const createSandbox = (overrides: Partial<CreateOptions> = {}) => {
+    const mock = createFetchMock([{ data: { sandboxCreate: sandboxInfo() } }]);
+    return Sandbox.create({
+      token: "t",
+      environmentId: "e",
+      fetch: mock.fetch,
+      ...overrides,
+    });
+  };
+
+  it("is silent by default", async () => {
+    await createSandbox();
+
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("prints progress when `verbose: true`", async () => {
+    await createSandbox({ verbose: true });
+
+    const lines = logged();
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.every(line => line.startsWith("[railway] "))).toBe(true);
+    expect(lines).toContainEqual(
+      expect.stringContaining("RailwaySandboxCreate"),
+    );
+  });
+
+  it("is enabled by RAILWAY_VERBOSE=1", async () => {
+    vi.stubEnv("RAILWAY_VERBOSE", "1");
+
+    await createSandbox();
+
+    expect(stderr).toHaveBeenCalled();
+  });
+
+  it("stays off for RAILWAY_VERBOSE=0", async () => {
+    vi.stubEnv("RAILWAY_VERBOSE", "0");
+
+    await createSandbox();
+
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("never logs the token", async () => {
+    await createSandbox({ token: "secret_token_value", verbose: true });
+
+    expect(logged().some(line => line.includes("secret_token_value"))).toBe(
+      false,
+    );
   });
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createLogger } from "../src/core/logger.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createLogger", () => {
+  it("is a no-op when verbose is off", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    createLogger(false)("nothing should print");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("writes a [railway]-prefixed line to stderr when verbose is on", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    createLogger(true)("hello");
+
+    expect(spy).toHaveBeenCalledWith("[railway] hello");
+  });
+});

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -8,6 +8,7 @@ export function clearRailwayEnv(): void {
   vi.stubEnv("RAILWAY_API_TOKEN", "");
   vi.stubEnv("RAILWAY_ENVIRONMENT_ID", "");
   vi.stubEnv("RAILWAY_GRAPHQL_ENDPOINT", "");
+  vi.stubEnv("RAILWAY_VERBOSE", "");
 }
 
 export interface FetchCall {


### PR DESCRIPTION
Adds an opt-in verbose mode (`verbose: true` or `RAILWAY_VERBOSE`) that prints human-readable `[railway]` progress lines to stderr, giving visibility into requests, readiness polling, and lifecycle when a create/fork/template build seems stuck.

- New `createLogger` (no-op when off); `verbose` on `RailwayClientConfig` resolves explicit → `RAILWAY_VERBOSE` → off
- Logs GraphQL requests (operation, timing, ok/fail/no-data), poll attempts ("waiting on … retry in Xms"), ready/terminal/timeout, create/fork/template/exec/destroy, and `sandbox not found`
- Tokens and `env`/template variable values are never logged (key names only)
- README verbose section; unit tests for logger and `RAILWAY_VERBOSE` resolution