### PR TITLE
fix(files): review hardening — early-ok protocol error, zero-consumption retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ await sandbox.files.write("/app/run.sh", "#!/bin/sh\n...", { mode: 0o755 });
 `AsyncIterable<Uint8Array>`, or a function returning a stream or iterable. It creates
 missing parent directories automatically. Strings, bytes, blobs, and function sources are
 retried automatically if the connection drops mid-transfer. A bare stream is one-shot: a
-drop surfaces `RailwayConnectionError` and may leave a partial file. Streams upload
+drop mid-stream surfaces `RailwayConnectionError` and may leave a partial file. Streams upload
 without buffering, so a large file can be pushed from disk; prefer the function form so
 a retry can read a fresh stream:
 

--- a/src/core/files-ws-client.ts
+++ b/src/core/files-ws-client.ts
@@ -308,6 +308,17 @@ export function connectFilesWs(args: {
             if (replyType === "ok") {
               disarm();
               pending.delete(id);
+              if (awaitingReady) {
+                // The server acked a write whose content was never sent;
+                // resolving would claim success for a file it never received.
+                const error = new FilesRemoteError(
+                  "protocol error: ok before write_ready",
+                  "start",
+                );
+                ready.reject(error);
+                settle.reject(error);
+                return;
+              }
               settle.resolve();
             }
           },

--- a/src/sandbox/files-transfer.ts
+++ b/src/sandbox/files-transfer.ts
@@ -56,17 +56,20 @@ function isTransientTransfer(error: unknown): boolean {
 }
 
 /**
- * A dropped session is retriable when the source can be replayed (the file
- * is truncated again by the next write_start). One-shot streams can't be,
- * so the error surfaces.
+ * A dropped session is retriable when the source can still produce the full
+ * content: it is replayable, or it was never pulled (a failure during the
+ * write_start handshake consumes nothing, so even one-shot streams are
+ * intact). The file is truncated again by the next write_start.
  */
 export function canRetryWrite(
   error: unknown,
-  replayable: boolean,
+  source: UploadSource,
   retries: number,
 ): boolean {
   return (
-    isTransientTransfer(error) && replayable && retries <= TRANSFER_MAX_RETRIES
+    isTransientTransfer(error) &&
+    (source.replayable || !source.consumed()) &&
+    retries <= TRANSFER_MAX_RETRIES
   );
 }
 
@@ -225,10 +228,60 @@ export interface UploadSource {
   size: number;
   /** Whether `chunks()` can produce the content again (enables retry). */
   replayable: boolean;
+  /** Whether the source has ever been pulled (one-shot sources can't replay after this). */
+  consumed: () => boolean;
 }
 
-/** Normalizes accepted write inputs to a chunk-source factory. */
+/**
+ * Normalizes accepted write inputs to a chunk-source factory and tracks
+ * whether the source was ever pulled: a one-shot source that was never
+ * started is still safe to retry.
+ */
 export function uploadSource(data: FileWriteData): UploadSource {
+  const source = normalizeSource(data);
+  let consumed = false;
+  return {
+    ...source,
+    chunks: () =>
+      markOnFirstPull(source.chunks(), () => {
+        consumed = true;
+      }),
+    consumed: () => consumed,
+  };
+}
+
+/**
+ * Wraps an iterable so `mark` fires when `next()` is first *called*, not when
+ * it resolves: a one-shot generator loses the in-flight value to any replay
+ * the moment it is pulled.
+ */
+function markOnFirstPull(
+  iterable: AsyncIterable<Uint8Array>,
+  mark: () => void,
+): AsyncIterable<Uint8Array> {
+  return {
+    [Symbol.asyncIterator]() {
+      const inner = iterable[Symbol.asyncIterator]();
+      const iterator: AsyncIterator<Uint8Array> = {
+        next: (...args) => {
+          mark();
+          return inner.next(...args);
+        },
+      };
+      if (inner.return) iterator.return = inner.return.bind(inner);
+      if (inner.throw) iterator.throw = inner.throw.bind(inner);
+      return iterator;
+    },
+  };
+}
+
+interface NormalizedSource {
+  chunks: () => AsyncIterable<Uint8Array>;
+  size: number;
+  replayable: boolean;
+}
+
+function normalizeSource(data: FileWriteData): NormalizedSource {
   if (typeof data === "string") {
     const bytes = new TextEncoder().encode(data);
     return { chunks: () => single(bytes), size: bytes.length, replayable: true };
@@ -250,7 +303,7 @@ export function uploadSource(data: FileWriteData): UploadSource {
 }
 
 /** The streaming-shaped write inputs; undefined when `data` is none of them. */
-function streamingSource(data: FileWriteData): UploadSource | undefined {
+function streamingSource(data: FileWriteData): NormalizedSource | undefined {
   if (typeof Blob !== "undefined" && data instanceof Blob) {
     return {
       chunks: () => streamChunks(data.stream()),

--- a/src/sandbox/files.ts
+++ b/src/sandbox/files.ts
@@ -114,8 +114,8 @@ export class SandboxFiles {
    * parent directories are created automatically. Strings, bytes, blobs, and
    * factory sources upload with retry if the session drops mid-transfer;
    * bare streams and async iterables upload unbuffered but are one-shot, so
-   * a dropped session surfaces as `RailwayConnectionError` (and a partial
-   * file may remain at `path`).
+   * a session dropped mid-stream surfaces as `RailwayConnectionError` (and a
+   * partial file may remain at `path`).
    *
    * Files are created `0644`; pass `mode` to set permissions (applied right
    * after the upload completes).
@@ -144,7 +144,7 @@ export class SandboxFiles {
         await this.#writeOnce(target, start, source);
         break;
       } catch (error) {
-        if (!canRetryWrite(error, source.replayable, ++retries)) {
+        if (!canRetryWrite(error, source, ++retries)) {
           throw this.#wrapError("write", target, error);
         }
         this.#log(`files write ${target} retrying after connection loss`);

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -132,7 +132,7 @@ export interface FileReadOptions {
 /**
  * Content accepted by `files.write`. Streams and async iterables upload
  * without buffering, so pushes larger than memory are safe, but they are
- * one-shot: a dropped session can't be retried. Pass a factory
+ * one-shot: a session dropped mid-stream can't be retried. Pass a factory
  * (`() => stream`) when the content can be produced again; the write is then
  * retried automatically like the in-memory forms.
  */

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -734,7 +734,7 @@ describe("files.write", () => {
     await expect(promise).resolves.toBeUndefined();
   }, 15_000);
 
-  it("does not retry one-shot stream sources after a drop", async () => {
+  it("does not retry one-shot stream sources dropped after streaming began", async () => {
     const { sandbox, ws } = await filesSandbox();
     async function* chunks() {
       yield enc("data");
@@ -743,8 +743,59 @@ describe("files.write", () => {
     const socket = await ws.nextSocket();
     const start = await socket.nextRequest();
     socket.serverReply("write_ready", start.id!);
+    // Drop only after the source has been pulled; a drop before that is now
+    // retried even for one-shot sources (nothing was consumed).
+    await until(() => socket.sentBinary.length > 0, "content frame sent");
     socket.serverClose(1006, "gone");
     await expect(promise).rejects.toBeInstanceOf(RailwayConnectionError);
+  });
+
+  it("retries a one-shot source when write_start fails with connection lost", async () => {
+    // The source was never pulled, so even a one-shot iterable is intact.
+    const { sandbox, ws } = await filesSandbox(2);
+    async function* chunks() {
+      yield enc("data");
+    }
+    const promise = sandbox.files.write("/f.bin", chunks());
+
+    const first = await ws.nextSocket();
+    const start = await first.nextRequest();
+    first.serverError(start.id!, "connection lost");
+
+    const second = await ws.nextSocket();
+    await acceptWrite(second, 1);
+    expect(second.sentBinary[0]?.payload).toEqual(enc("data"));
+    await expect(promise).resolves.toBeUndefined();
+  }, 15_000);
+
+  it("retries a one-shot source when the connection drops before write_ready", async () => {
+    const { sandbox, ws } = await filesSandbox(2);
+    async function* chunks() {
+      yield enc("data");
+    }
+    const promise = sandbox.files.write("/f.bin", chunks());
+
+    const first = await ws.nextSocket();
+    await first.nextRequest();
+    first.serverClose(1006, "gone");
+
+    const second = await ws.nextSocket();
+    await acceptWrite(second, 1);
+    expect(second.sentBinary[0]?.payload).toEqual(enc("data"));
+    await expect(promise).resolves.toBeUndefined();
+  }, 15_000);
+
+  it("rejects a write acked before write_ready as a protocol error", async () => {
+    const { sandbox, ws } = await filesSandbox();
+    const promise = sandbox.files.write("/f.txt", "data");
+    const socket = await ws.nextSocket();
+    const request = await socket.nextRequest();
+    socket.serverReply("ok", request.id!);
+
+    const error = await promise.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(SandboxFilesError);
+    expect((error as Error).message).toContain("ok before write_ready");
+    expect(socket.sentBinary).toHaveLength(0);
   });
 
   it("rejects when write_start fails", async () => {

--- a/tests/sandbox.e2e.test.ts
+++ b/tests/sandbox.e2e.test.ts
@@ -357,6 +357,17 @@ describe.runIf(live)("files e2e (live)", () => {
     expect(await sandbox.files.exists("/tmp/files-e2e/nested/b.txt")).toBe(false);
   }, 120_000);
 
+  it("creates missing parent directories on write", async () => {
+    // Unique path so the write_start-fails → mkdir → retry fallback runs on
+    // the live bridge (it assumes the connection survives the failed start).
+    const path = `/tmp/files-e2e-parents-${Date.now()}/deep/nested/file.txt`;
+    await sandbox.files.write(path, "made it\n");
+    expect(await sandbox.files.read(path)).toBe("made it\n");
+
+    const parent = await sandbox.files.stat(path.slice(0, path.lastIndexOf("/")));
+    expect(parent.isDir).toBe(true);
+  }, 120_000);
+
   it("applies the mode option", async () => {
     await sandbox.files.write("/tmp/run.sh", "#!/bin/sh\necho ok\n", {
       mode: 0o755,


### PR DESCRIPTION
Fixes from the post-merge review of #21.

- An `ok` reply arriving before `write_ready` now rejects as a protocol error instead of hanging the write forever with the inactivity guard disarmed
- `uploadSource` tracks whether the source was ever pulled, so one-shot streams that fail during the `write_start` handshake (drop or server "connection lost") retry safely; mid-stream drops still surface
- Live e2e now covers the missing-parent mkdir fallback, pinning the assumption that the bridge connection survives a failed `write_start`