### PR TITLE
feat(iac): wire-contract v1 + optimistic apply lock (configEtag)

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -36,6 +36,12 @@ export class RailwayConnectionError extends RailwayError {
   }
 }
 
+/** Stable code backboard sets in error extensions when an apply's base config is stale. */
+export const STALE_ENVIRONMENT_BASE_CODE = "STALE_ENVIRONMENT_BASE";
+
+/** Thrown by IaC apply when the environment changed since the plan's base snapshot. */
+export class StaleEnvironmentError extends RailwayError {}
+
 export class RailwayGraphQLError extends RailwayError {
   readonly status: number;
   readonly errors: readonly RailwayGraphQLErrorItem[];

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -2,7 +2,12 @@ import { composePatch, graphToEnvironmentConfig } from "./compiler.js";
 import type { GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, VariableValue } from "./graph.js";
 import type { EnvironmentConfig } from "./schema.js";
 
-export const RAILWAY_CHANGE_SET_VERSION = 0 as const;
+// Wire-contract version for the RailwayChangeSet exchanged with backboard.
+// v1 adds the optional base-config etag handshake on apply (compare-and-swap).
+// Compat guarantee: backboard accepts every version in SUPPORTED_CHANGE_SET_VERSIONS,
+// so backboard must deploy support for a new version before the SDK/CLI emit it.
+export const RAILWAY_CHANGE_SET_VERSION = 1 as const;
+export const SUPPORTED_CHANGE_SET_VERSIONS = [0, 1] as const;
 
 export type RailwayChangeSetVersion = typeof RAILWAY_CHANGE_SET_VERSION;
 export type ChangeSeverity = "safe" | "destructive";

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -404,10 +404,12 @@ function formatVariableDiffValue(value: VariableValue | undefined, resourcesByAd
     const name = resourcesByAddress.get(value.resource)?.name ?? value.resource.split(".").slice(1).join(".") ?? value.resource;
     return `${name}.${value.output}`;
   }
+  if (value.type === "sharedReference") return `shared.${value.name}`;
   return formatDiffValue(normalizeVariableForDiff(value, resourcesByAddress));
 }
 
 function normalizeVariableForDiff(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>): unknown {
+  if (value?.type === "sharedReference") return { type: "literal", value: `\${{shared.${value.name}}}` };
   if (value?.type !== "reference") return value;
   const name = resourcesByAddress.get(value.resource)?.name ?? value.resource.split(".").slice(1).join(".") ?? value.resource;
   return { type: "literal", value: `\${{${name}.${value.output}}}` };

--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -2,6 +2,7 @@ import { parse } from "graphql";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { normalizeRailwayClientConfig, type RailwayClientConfig, type NormalizedRailwayClientConfig } from "../core/config.js";
 import { requestGraphQL } from "../core/graphql-client.js";
+import { RailwayGraphQLError, StaleEnvironmentError, STALE_ENVIRONMENT_BASE_CODE } from "../core/errors.js";
 import type {
   BucketCreateInput,
   ServiceCreateInput,
@@ -17,6 +18,8 @@ export interface CurrentEnvironmentResult {
   environmentId: string;
   environmentName?: string | undefined;
   config: EnvironmentConfig;
+  /** Opaque snapshot token of the environment config the plan was computed against. */
+  configEtag?: string | undefined;
   serviceNamesById: Record<string, string>;
   bucketNamesById: Record<string, string>;
   customDomainsByServiceId: Record<string, Record<string, { port?: number }>>;
@@ -71,9 +74,9 @@ export class IacClient {
 
   async getCurrentEnvironment(environmentId: string, options: { decryptVariables?: boolean } = {}): Promise<CurrentEnvironmentResult> {
     const data = await gql<{
-      environment: { id: string; name?: string; projectId?: string; config: EnvironmentConfig };
+      environment: { id: string; name?: string; projectId?: string; config: EnvironmentConfig; configEtag?: string };
     }, { environmentId: string; decryptVariables: boolean }>(this.#config, `query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
-      environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) }
+      environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag }
     }`, { environmentId, decryptVariables: options.decryptVariables ?? false });
 
     const projectName = data.environment.projectId ? await this.getProjectName(data.environment.projectId) : undefined;
@@ -89,6 +92,7 @@ export class IacClient {
       serviceNamesById: Object.fromEntries(services.map(service => [service.id, service.name])),
       bucketNamesById: Object.fromEntries(buckets.map(bucket => [bucket.id, bucket.name])),
       customDomainsByServiceId,
+      ...(data.environment.configEtag ? { configEtag: data.environment.configEtag } : {}),
     };
   }
 
@@ -170,13 +174,23 @@ export class IacClient {
     return data.environmentPreviewChangeSet;
   }
 
-  async applyChangeSet({ environmentId, changeSet, commitMessage }: { environmentId: string; changeSet: RailwayChangeSet; commitMessage?: string }): Promise<ChangeSetApplyResult> {
-    const variables: { environmentId: string; input: RailwayChangeSet; commitMessage?: string } = { environmentId, input: changeSet };
+  async applyChangeSet({ environmentId, changeSet, commitMessage, baseEtag }: { environmentId: string; changeSet: RailwayChangeSet; commitMessage?: string; baseEtag?: string }): Promise<ChangeSetApplyResult> {
+    const variables: { environmentId: string; input: RailwayChangeSet; commitMessage?: string; baseConfigEtag?: string } = { environmentId, input: changeSet };
     if (commitMessage !== undefined) variables.commitMessage = commitMessage;
-    const data = await gql<{ environmentApplyChangeSet: ChangeSetApplyResult }, typeof variables>(this.#config, `mutation IacApplyChangeSet($environmentId: String!, $input: JSON!, $commitMessage: String) {
-      environmentApplyChangeSet(environmentId: $environmentId, input: $input, commitMessage: $commitMessage) { id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs } }
-    }`, variables);
-    return data.environmentApplyChangeSet;
+    // Optimistic concurrency: the server rejects the apply if the environment moved
+    // since this plan's base. Omitted etag (older server/client) skips the check.
+    if (baseEtag !== undefined) variables.baseConfigEtag = baseEtag;
+    try {
+      const data = await gql<{ environmentApplyChangeSet: ChangeSetApplyResult }, typeof variables>(this.#config, `mutation IacApplyChangeSet($environmentId: String!, $input: JSON!, $commitMessage: String, $baseConfigEtag: String) {
+        environmentApplyChangeSet(environmentId: $environmentId, input: $input, commitMessage: $commitMessage, baseConfigEtag: $baseConfigEtag) { id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs } }
+      }`, variables);
+      return data.environmentApplyChangeSet;
+    } catch (error) {
+      if (isStaleBaseError(error)) {
+        throw new StaleEnvironmentError("The environment changed since this plan was computed. Re-run plan and review the changes before applying.", { cause: error });
+      }
+      throw error;
+    }
   }
 
   async commitStagedPatch({ environmentId, message, skipDeploys }: { environmentId: string; message?: string; skipDeploys?: boolean }): Promise<string> {
@@ -243,6 +257,11 @@ export class IacClient {
 
 async function gql<TResult, TVariables>(config: NormalizedRailwayClientConfig, source: string, variables: TVariables): Promise<TResult> {
   return requestGraphQL(config, parse(source) as TypedDocumentNode<TResult, TVariables>, variables);
+}
+
+function isStaleBaseError(error: unknown): boolean {
+  if (!(error instanceof RailwayGraphQLError)) return false;
+  return error.errors.some(item => item.extensions?.code === STALE_ENVIRONMENT_BASE_CODE);
 }
 
 function extractVolumeIdsByServiceName({ currentConfig, serviceIdsByName }: { currentConfig?: EnvironmentConfig; serviceIdsByName: Record<string, string> }): Record<string, string> {

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -286,13 +286,17 @@ function variablesToEnvironmentConfig(variables: Record<string, VariableValue>, 
       .filter((entry): entry is [string, Exclude<VariableValue, { type: "preserve" }>] => entry[1].type !== "preserve")
       .map(([key, value]) => [
         key,
-        value.type === "literal" ? literalVariable(value) : value.type === "raw" ? value.value : referenceVariable(value, resourceNamesById),
+        value.type === "literal" ? literalVariable(value) : value.type === "raw" ? value.value : value.type === "sharedReference" ? sharedReferenceVariable(value) : referenceVariable(value, resourceNamesById),
       ]),
   );
 }
 
 function referenceVariable(value: Extract<VariableValue, { type: "reference" }>, resourceNamesById: Record<string, string>): VariableConfig {
   return { value: `\${{${resourceNamesById[value.resource] ?? value.resource}.${value.output}}}` };
+}
+
+function sharedReferenceVariable(value: Extract<VariableValue, { type: "sharedReference" }>): VariableConfig {
+  return { value: `\${{shared.${value.name}}}` };
 }
 
 function literalVariable(value: Extract<VariableValue, { type: "literal" }>): VariableConfig {

--- a/src/iac/graph.ts
+++ b/src/iac/graph.ts
@@ -103,6 +103,7 @@ export interface GroupNode extends GraphResourceBase {
 export type VariableValue =
   | ({ type: "literal" } & VariableConfig)
   | { type: "reference"; resource: ResourceAddress; output: string }
+  | { type: "sharedReference"; name: string }
   | { type: "preserve" }
   | { type: "raw"; value: VariableConfig };
 

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -229,6 +229,8 @@ async function applyRailwayIac(input: EvaluatedCommandInput): Promise<RailwayIac
     environmentId: context.environmentId,
     changeSet: planned.changeSet,
     commitMessage: "Apply Railway configuration",
+    // Base snapshot the plan was diffed against; backboard rejects a stale apply.
+    ...(planned.currentEnvironment?.configEtag ? { baseEtag: planned.currentEnvironment.configEtag } : {}),
   });
 
   return {

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -35,6 +35,7 @@ export interface RailwayContextInput {
 export interface RailwayContext extends RailwayContextInput {
   randomString: (label?: string, bytes?: number) => string;
   isEnvironment: (name: string) => boolean;
+  shared: SharedVariableRef;
 }
 
 export type RailwayProgram = (
@@ -61,6 +62,7 @@ export function createRailwayContext(input: RailwayContextInput = {}): RailwayCo
     randomString: (label = "random", bytes = 12) =>
       createHash("sha256").update(`railway-iac:${environment ?? "default"}:${label}`).digest("hex").slice(0, bytes * 2),
     isEnvironment: (name: string) => environment === name,
+    shared: createSharedVariableRefs(),
   };
 }
 
@@ -121,6 +123,7 @@ export type MongoVariable = RailwayProvidedVariable | "MONGO_INITDB_ROOT_PASSWOR
 export type MySqlVariable = RailwayProvidedVariable | "MYSQL_DATABASE" | "MYSQL_PUBLIC_URL" | "MYSQL_ROOT_PASSWORD" | "MYSQL_URL" | "MYSQLDATABASE" | "MYSQLHOST" | "MYSQLPASSWORD" | "MYSQLPORT" | "MYSQLUSER";
 export type DatabaseVariable<E extends DatabaseNode["engine"]> = E extends "postgres" ? PostgresVariable : E extends "redis" ? RedisVariable : E extends "mongo" ? MongoVariable : E extends "mysql" ? MySqlVariable : RailwayProvidedVariable | string;
 export type ServiceVariableRef<K extends string = RailwayProvidedVariable | string> = { readonly [P in K]: VariableValue };
+export type SharedVariableRef = { readonly [name: string]: VariableValue } & { readonly [name: string]: any };
 export type ReferencableServiceNode<K extends string = RailwayProvidedVariable | string> = ServiceNode & { readonly env: ServiceVariableRef<K> };
 export type ReferencableDatabaseNode<E extends DatabaseNode["engine"]> = DatabaseNode & { readonly env: ServiceVariableRef<DatabaseVariable<E>> };
 
@@ -245,6 +248,19 @@ export function preserve(): VariableValue {
 
 function variableReference(resource: ResourceNode, output: string): VariableValue {
   return { type: "reference", resource: resource.address, output };
+}
+
+function sharedVariableReference(name: string): VariableValue {
+  return { type: "sharedReference", name };
+}
+
+function createSharedVariableRefs(): SharedVariableRef {
+  return new Proxy({} as SharedVariableRef, {
+    get(_target, property) {
+      if (typeof property !== "string") return undefined;
+      return sharedVariableReference(property);
+    },
+  });
 }
 
 function createVariableRefAccessor(resource: ResourceNode): ServiceVariableRef<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export {
   RailwayError,
   RailwayGraphQLError,
   type RailwayGraphQLErrorItem,
+  StaleEnvironmentError,
+  STALE_ENVIRONMENT_BASE_CODE,
 } from "./core/errors.js";
 export {
   bucket,

--- a/tests/fixtures/iac-apply/.railway/railway.ts
+++ b/tests/fixtures/iac-apply/.railway/railway.ts
@@ -1,0 +1,10 @@
+// Fixture for the runner end-to-end thread test. Imports from src so the test
+// exercises current source (not built dist). One new service → the diff yields a
+// create change, which drives plan → preview → apply through the runner.
+import { defineRailway, github, project, service } from "../../../../src/iac/index.js";
+
+export default defineRailway(() =>
+  project("e2e-thread", {
+    resources: [service("web", { source: github("acme/web") })],
+  }),
+);

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { RailwayGraphQLError, StaleEnvironmentError } from "../src/index.js";
+import { IacClient } from "../src/iac/client.js";
+import type { RailwayChangeSet } from "../src/iac/change-set.js";
+import { createFetchMock } from "./test-helpers.js";
+
+const changeSet: RailwayChangeSet = { version: 1, changes: [], diagnostics: [] };
+
+const applyOk = {
+  data: {
+    environmentApplyChangeSet: {
+      id: "op_1",
+      status: "applied",
+      changes: [],
+      diagnostics: [],
+      deploymentId: null,
+      stagedPatchId: null,
+    },
+  },
+};
+
+const client = (fetch: typeof globalThis.fetch) => new IacClient({ token: "t", fetch });
+const variablesOf = (call: { body: { variables?: unknown } } | undefined) =>
+  (call?.body.variables ?? {}) as Record<string, unknown>;
+
+describe("IaC apply — configEtag handshake", () => {
+  it("sends baseConfigEtag when a base etag is provided", async () => {
+    const mock = createFetchMock([applyOk]);
+
+    await client(mock.fetch).applyChangeSet({ environmentId: "e1", changeSet, baseEtag: "etag-xyz" });
+
+    expect(variablesOf(mock.calls[0]).baseConfigEtag).toBe("etag-xyz");
+  });
+
+  it("omits baseConfigEtag when no base etag is provided (backward compatible)", async () => {
+    const mock = createFetchMock([applyOk]);
+
+    await client(mock.fetch).applyChangeSet({ environmentId: "e1", changeSet });
+
+    expect(variablesOf(mock.calls[0]).baseConfigEtag).toBeUndefined();
+  });
+
+  it("maps a STALE_ENVIRONMENT_BASE rejection to StaleEnvironmentError", async () => {
+    const mock = createFetchMock([
+      { errors: [{ message: "stale", extensions: { code: "STALE_ENVIRONMENT_BASE" } }] },
+    ]);
+
+    await expect(
+      client(mock.fetch).applyChangeSet({ environmentId: "e1", changeSet, baseEtag: "old" }),
+    ).rejects.toBeInstanceOf(StaleEnvironmentError);
+  });
+
+  it("rethrows unrelated GraphQL errors unchanged", async () => {
+    const mock = createFetchMock([
+      { errors: [{ message: "boom", extensions: { code: "INTERNAL_SERVER_ERROR" } }] },
+    ]);
+
+    const promise = client(mock.fetch).applyChangeSet({ environmentId: "e1", changeSet, baseEtag: "old" });
+    await expect(promise).rejects.toBeInstanceOf(RailwayGraphQLError);
+    await expect(promise).rejects.not.toBeInstanceOf(StaleEnvironmentError);
+  });
+
+  it("surfaces configEtag from the current environment", async () => {
+    const mock = createFetchMock([
+      { data: { environment: { id: "e1", name: "production", projectId: "p1", config: {}, configEtag: "etag-abc" } } },
+      { data: { project: { name: "proj" } } },
+      { data: { project: { services: { edges: [] } } } },
+      { data: { project: { buckets: { edges: [] } } } },
+    ]);
+
+    const current = await client(mock.fetch).getCurrentEnvironment("e1");
+
+    expect(current.configEtag).toBe("etag-abc");
+  });
+});

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RailwayGraphQLError, StaleEnvironmentError } from "../src/index.js";
 import { IacClient } from "../src/iac/client.js";
 import type { RailwayChangeSet } from "../src/iac/change-set.js";
+import { runRailwayIac } from "../src/iac/runner.js";
 import { createFetchMock } from "./test-helpers.js";
 
 const changeSet: RailwayChangeSet = { version: 1, changes: [], diagnostics: [] };
@@ -72,5 +74,37 @@ describe("IaC apply — configEtag handshake", () => {
     const current = await client(mock.fetch).getCurrentEnvironment("e1");
 
     expect(current.configEtag).toBe("etag-abc");
+  });
+});
+
+describe("IaC runner — threads configEtag from plan into apply", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const fixture = fileURLToPath(new URL("./fixtures/iac-apply/.railway/railway.ts", import.meta.url));
+
+  it("captures configEtag during plan and sends it as baseConfigEtag on apply", async () => {
+    // Ordered responses for: env config, project name, services, buckets, preview, apply.
+    const mock = createFetchMock([
+      { data: { environment: { id: "e1", name: "production", projectId: "p1", config: {}, configEtag: "etag-LIVE" } } },
+      { data: { project: { name: "e2e-thread" } } },
+      { data: { project: { services: { edges: [] } } } },
+      { data: { project: { buckets: { edges: [] } } } },
+      { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [], diagnostics: [] }, diagnostics: [], effects: [] } } },
+      { data: { environmentApplyChangeSet: { id: "op_1", status: "applied", changes: [], diagnostics: [], deploymentId: "deploy_1", stagedPatchId: null } } },
+    ]);
+    vi.stubGlobal("fetch", mock.fetch);
+
+    const result = await runRailwayIac({
+      command: "apply",
+      file: fixture,
+      backboard: { token: "t", environmentId: "e1" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe("apply");
+
+    const applyCall = mock.calls.find(call => call.body.query.includes("environmentApplyChangeSet"));
+    expect(applyCall, "expected an environmentApplyChangeSet request").toBeDefined();
+    expect((applyCall?.body.variables as Record<string, unknown>).baseConfigEtag).toBe("etag-LIVE");
   });
 });

--- a/tests/iac.e2e.test.ts
+++ b/tests/iac.e2e.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { runRailwayIac, type RailwayIacCurrentResponse } from "../src/iac/runner.js";
+
+/**
+ * Live IaC test: runs whenever RAILWAY_API_TOKEN + RAILWAY_ENVIRONMENT_ID are set
+ * (loaded from .env by `mise run test`); skips otherwise so the unit suite stays
+ * offline. Read-only — it exercises the `current` path against the real backboard
+ * and asserts the configEtag handshake field comes back populated. No mutations.
+ */
+const live = Boolean(process.env.RAILWAY_API_TOKEN) && Boolean(process.env.RAILWAY_ENVIRONMENT_ID);
+
+const fixture = fileURLToPath(new URL("./fixtures/iac-apply/.railway/railway.ts", import.meta.url));
+
+describe.skipIf(!live)("IaC live — configEtag", () => {
+  it("fetches a non-empty configEtag from the real environment", async () => {
+    const result = (await runRailwayIac({
+      command: "current",
+      file: fixture,
+      backboard: {
+        token: process.env.RAILWAY_API_TOKEN!,
+        environmentId: process.env.RAILWAY_ENVIRONMENT_ID!,
+        ...(process.env.RAILWAY_AUTH_TYPE === "project-token" ? { authType: "project-token" as const } : {}),
+        ...(process.env.RAILWAY_GRAPHQL_ENDPOINT ? { endpoint: process.env.RAILWAY_GRAPHQL_ENDPOINT } : {}),
+      },
+    })) as RailwayIacCurrentResponse;
+
+    expect(result.diagnostics.filter(d => d.severity === "error")).toEqual([]);
+    expect(result.currentEnvironment?.configEtag).toEqual(expect.any(String));
+    expect((result.currentEnvironment?.configEtag ?? "").length).toBeGreaterThan(0);
+  });
+});

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { bucket, createRailwayContext, diffGraphs, graphToEnvironmentConfig, postgres, project, service } from "../src/index.js";
+import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, github, graphToEnvironmentConfig, image, postgres, project, service } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS } from "../src/iac/change-set.js";
+import { preserve } from "../src/iac/sdk.js";
 
 describe("Railway IaC", () => {
   it("emits the current change-set wire version", () => {
@@ -65,5 +66,80 @@ describe("Railway IaC", () => {
 
   it("typechecks known bucket regions", () => {
     expect(bucket("assets", { region: "sjc" }).config?.region).toBe("sjc");
+  });
+
+  // The GA gate: compiling a desired graph to config and reading it straight back
+  // must produce zero changes. This is the "import → plan → ∅" round-trip the
+  // runner performs against a live environment.
+  it("plans no changes for an unchanged round-tripped config", () => {
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [
+        service("web", { source: github("railwayapp/demo", { branch: "main" }), env: { PUBLIC_FLAG: "on" } }),
+        service("worker", { source: image("ghcr.io/acme/worker:1.2.3") }),
+      ],
+    }));
+
+    const current = environmentConfigToGraph(graphToEnvironmentConfig(desired), { projectName: "app" });
+
+    expect(diffGraphs({ current, desired }).changes).toEqual([]);
+  });
+
+  it("marks removing a service as a destructive delete", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "railwayapp/demo" } }, api: { source: { repo: "railwayapp/api" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("railwayapp/demo") })],
+    }));
+
+    const deletion = diffGraphs({ current, desired }).changes.find(change => change.kind === "resource.delete");
+    expect(deletion).toMatchObject({ kind: "resource.delete", address: "service.api", severity: "destructive" });
+  });
+
+  it("treats variable removal as destructive and addition as safe", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "r" }, variables: { OLD: { value: "1" } } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("r"), env: { NEW: "2" } })],
+    }));
+
+    const changes = diffGraphs({ current, desired }).changes;
+    expect(changes).toContainEqual(expect.objectContaining({ kind: "variable.delete", variable: "OLD", severity: "destructive" }));
+    expect(changes).toContainEqual(expect.objectContaining({ kind: "variable.set", variable: "NEW", severity: "safe" }));
+  });
+
+  it("never plans a change for a preserve() variable", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "r" }, variables: { SECRET: { value: "existing" } } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("r"), env: { SECRET: preserve() } })],
+    }));
+
+    const varChanges = diffGraphs({ current, desired }).changes.filter(change => change.kind.startsWith("variable"));
+    expect(varChanges).toEqual([]);
+  });
+
+  it("refuses to manage a service still owned by railway.json/toml", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "r" }, configFile: "railway.json" } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("r") })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({ current, desired });
+    expect(diagnostics).toContainEqual(expect.objectContaining({ severity: "error", message: expect.stringContaining("railway.json") }));
+    expect(changes).toEqual([]);
+  });
+
+  it("flags a bucket region change as an immutable-region error", () => {
+    const current = environmentConfigToGraph({ buckets: { assets: { region: "sjc" } } }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", { resources: [bucket("assets", { region: "ams" })] }));
+
+    expect(diffGraphs({ current, desired }).diagnostics).toContainEqual(
+      expect.objectContaining({ severity: "error", message: expect.stringContaining("region") }),
+    );
   });
 });

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from "vitest";
 
 import { bucket, createRailwayContext, diffGraphs, graphToEnvironmentConfig, postgres, project, service } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
+import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS } from "../src/iac/change-set.js";
 
 describe("Railway IaC", () => {
+  it("emits the current change-set wire version", () => {
+    const current = projectDefinitionToGraph(project("app", { resources: [] }));
+    const desired = projectDefinitionToGraph(project("app", { resources: [service("web", {})] }));
+
+    expect(RAILWAY_CHANGE_SET_VERSION).toBe(1);
+    expect(SUPPORTED_CHANGE_SET_VERSIONS).toContain(RAILWAY_CHANGE_SET_VERSION);
+    expect(diffGraphs({ current, desired }).version).toBe(1);
+  });
+
+
   it("compiles shared variable references from context", () => {
     const ctx = createRailwayContext();
     const graph = projectDefinitionToGraph(project("app", {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { bucket, diffGraphs, graphToEnvironmentConfig, postgres, project } from "../src/index.js";
+import { bucket, createRailwayContext, diffGraphs, graphToEnvironmentConfig, postgres, project, service } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 
 describe("Railway IaC", () => {
+  it("compiles shared variable references from context", () => {
+    const ctx = createRailwayContext();
+    const graph = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { env: { API_KEY: ctx.shared.API_KEY, DASHED: ctx.shared["DASHED-KEY"] } })],
+    }));
+
+    expect(graphToEnvironmentConfig(graph).services?.web?.variables).toEqual({
+      API_KEY: { value: "${{shared.API_KEY}}" },
+      DASHED: { value: "${{shared.DASHED-KEY}}" },
+    });
+  });
+
   it("maps database region to service and volume placement", () => {
     const graph = projectDefinitionToGraph(project("app", {
       resources: [postgres("db", { region: "europe-west4" })],


### PR DESCRIPTION
## Item 1 — wire contract + apply lock
IaC is stateless — it diffs the desired graph against the **live** environment at plan time, and nothing checked that the environment still matched that base at apply time. So two concurrent applies (or a dashboard edit between plan and apply) could apply a changeset computed against a stale base.

- **Wire version → 1.** `diffGraphs` emits `version: 1`; `SUPPORTED_CHANGE_SET_VERSIONS` documents the accepted range. Compat guarantee: backboard accepts every supported version, so **backboard must deploy support before clients emit a new version**.
- **configEtag handshake.** `getCurrentEnvironment` captures the opaque `Environment.configEtag` the plan was computed against; the runner threads it into `environmentApplyChangeSet` as `baseConfigEtag`.
- **Stale-base rejection.** Backboard's `extensions.code = STALE_ENVIRONMENT_BASE` maps to a typed `StaleEnvironmentError` ("re-run plan…"). Omitting the etag (older server/client) skips the check — fully backward-compatible.
- Also includes the previously-staged `ctx.shared.NAME` shared-variable references.

## Item 2 — test coverage (SDK side)
The apply path can mutate real infra, so it's locked down:

- **`import → plan → ∅` round-trip invariant** — the GA gate.
- Destructive detection: resource delete, variable delete (destructive) vs variable set (safe).
- `preserve()` never plans a change.
- `railway.json/toml` migration guard emits an error and plans nothing.
- Bucket region change flagged immutable.
- configEtag handshake: apply sends `baseConfigEtag` (omits when absent), `STALE_ENVIRONMENT_BASE` → `StaleEnvironmentError`, other GraphQL errors pass through, `getCurrentEnvironment` surfaces `configEtag`.

## Validation
- `mise run typecheck` — clean
- `mise run test` — **144 passed** (incl. round-trip ∅, destructive paths, etag handshake)

## Deploy ordering
Backboard CAS PR must deploy before this SDK/CLI emits v1 — already merged.