### PR TITLE
chore: release v3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "TypeScript SDK for Railway.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump `3.3.1` → `3.3.2` for release.

Once merged, push tag `v3.3.2` at the merge commit to trigger `release.yml` (npm publish + GitHub release).

Includes:
- #26 — fix(exec): send cwd/env to the sandbox instead of wrapping the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)