### PR TITLE
chore(iac): add .railway config + dedicated IAC_E2E_* namespace

### DIFF
--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -22,7 +22,7 @@ export default defineRailway(() =>
     resources: [
       fn("iac-e2e", {
         source: github("railwayapp/railway-ts-sdk"),
-        start: "pnpm exec vitest run tests/*.e2e.test.ts",
+        start: "pnpm exec vitest run tests/iac.e2e.test.ts",
         deploy: { cronSchedule: "0 7 * * *" }, // nightly, 07:00 UTC
         env: {
           // Dedicated namespace — NOT RAILWAY_*, which the platform auto-injects

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,0 +1,33 @@
+import { defineRailway, fn, github, preserve, project } from "railway/iac";
+
+/**
+ * Dogfood: the IaC SDK's own live e2e runner, provisioned with the IaC SDK.
+ *
+ * Deploy this into a DEDICATED runner project — NOT the throwaway the e2e
+ * targets, so the runner can't fight its own test environment. Set these as
+ * Railway variables on the service; they're preserve()d here so this file
+ * never carries secrets:
+ *   RAILWAY_API_TOKEN       project token scoped to the e2e throwaway project
+ *   RAILWAY_ENVIRONMENT_ID  the e2e throwaway environment id
+ *
+ * The committed live suite is read-only (`current`), so this is safe to run
+ * unattended. Wire failure notification (e.g. a Slack webhook) before relying
+ * on it as a canary — a silent red cron is worse than none.
+ */
+export default defineRailway(() =>
+  project("railway-ts-sdk-e2e", {
+    resources: [
+      fn("iac-e2e", {
+        source: github("railwayapp/railway-ts-sdk"),
+        start: "pnpm exec vitest run tests/*.e2e.test.ts",
+        deploy: { cronSchedule: "0 7 * * *" }, // nightly, 07:00 UTC
+        env: {
+          RAILWAY_API_TOKEN: preserve(),
+          RAILWAY_ENVIRONMENT_ID: preserve(),
+          RAILWAY_AUTH_TYPE: "project-token",
+          RAILWAY_GRAPHQL_ENDPOINT: "https://backboard.railway.app/graphql/v2",
+        },
+      }),
+    ],
+  }),
+);

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,4 +1,7 @@
-import { defineRailway, fn, github, preserve, project } from "railway/iac";
+// This repo IS the `railway` package, so it can't import itself by name
+// (`railway/iac` resolves to node_modules/railway, which doesn't exist here).
+// Reference the local source directly — consumers use `from "railway/iac"`.
+import { defineRailway, fn, github, preserve, project } from "../src/iac/index.js";
 
 /**
  * Dogfood: the IaC SDK's own live e2e runner, provisioned with the IaC SDK.
@@ -7,8 +10,8 @@ import { defineRailway, fn, github, preserve, project } from "railway/iac";
  * targets, so the runner can't fight its own test environment. Set these as
  * Railway variables on the service; they're preserve()d here so this file
  * never carries secrets:
- *   RAILWAY_API_TOKEN       project token scoped to the e2e throwaway project
- *   RAILWAY_ENVIRONMENT_ID  the e2e throwaway environment id
+ *   IAC_E2E_API_TOKEN       project token scoped to the e2e throwaway project
+ *   IAC_E2E_ENVIRONMENT_ID  the e2e throwaway environment id
  *
  * The committed live suite is read-only (`current`), so this is safe to run
  * unattended. Wire failure notification (e.g. a Slack webhook) before relying
@@ -22,10 +25,12 @@ export default defineRailway(() =>
         start: "pnpm exec vitest run tests/*.e2e.test.ts",
         deploy: { cronSchedule: "0 7 * * *" }, // nightly, 07:00 UTC
         env: {
-          RAILWAY_API_TOKEN: preserve(),
-          RAILWAY_ENVIRONMENT_ID: preserve(),
-          RAILWAY_AUTH_TYPE: "project-token",
-          RAILWAY_GRAPHQL_ENDPOINT: "https://backboard.railway.app/graphql/v2",
+          // Dedicated namespace — NOT RAILWAY_*, which the platform auto-injects
+          // (RAILWAY_ENVIRONMENT_ID would resolve to this runner's own env).
+          IAC_E2E_API_TOKEN: preserve(),
+          IAC_E2E_ENVIRONMENT_ID: preserve(),
+          IAC_E2E_AUTH_TYPE: "project-token",
+          IAC_E2E_GRAPHQL_ENDPOINT: "https://backboard.railway.app/graphql/v2",
         },
       }),
     ],

--- a/tests/iac.e2e.test.ts
+++ b/tests/iac.e2e.test.ts
@@ -5,12 +5,16 @@ import { describe, expect, it } from "vitest";
 import { runRailwayIac, type RailwayIacCurrentResponse } from "../src/iac/runner.js";
 
 /**
- * Live IaC test: runs whenever RAILWAY_API_TOKEN + RAILWAY_ENVIRONMENT_ID are set
+ * Live IaC test: runs whenever IAC_E2E_API_TOKEN + IAC_E2E_ENVIRONMENT_ID are set
  * (loaded from .env by `mise run test`); skips otherwise so the unit suite stays
  * offline. Read-only — it exercises the `current` path against the real backboard
  * and asserts the configEtag handshake field comes back populated. No mutations.
+ *
+ * These use a dedicated IAC_E2E_* namespace on purpose: the RAILWAY_* names are
+ * auto-injected by the platform (e.g. RAILWAY_ENVIRONMENT_ID), so a runner hosted
+ * on Railway would otherwise read its own environment instead of the target.
  */
-const live = Boolean(process.env.RAILWAY_API_TOKEN) && Boolean(process.env.RAILWAY_ENVIRONMENT_ID);
+const live = Boolean(process.env.IAC_E2E_API_TOKEN) && Boolean(process.env.IAC_E2E_ENVIRONMENT_ID);
 
 const fixture = fileURLToPath(new URL("./fixtures/iac-apply/.railway/railway.ts", import.meta.url));
 
@@ -20,10 +24,10 @@ describe.skipIf(!live)("IaC live — configEtag", () => {
       command: "current",
       file: fixture,
       backboard: {
-        token: process.env.RAILWAY_API_TOKEN!,
-        environmentId: process.env.RAILWAY_ENVIRONMENT_ID!,
-        ...(process.env.RAILWAY_AUTH_TYPE === "project-token" ? { authType: "project-token" as const } : {}),
-        ...(process.env.RAILWAY_GRAPHQL_ENDPOINT ? { endpoint: process.env.RAILWAY_GRAPHQL_ENDPOINT } : {}),
+        token: process.env.IAC_E2E_API_TOKEN!,
+        environmentId: process.env.IAC_E2E_ENVIRONMENT_ID!,
+        ...(process.env.IAC_E2E_AUTH_TYPE === "project-token" ? { authType: "project-token" as const } : {}),
+        ...(process.env.IAC_E2E_GRAPHQL_ENDPOINT ? { endpoint: process.env.IAC_E2E_GRAPHQL_ENDPOINT } : {}),
       },
     })) as RailwayIacCurrentResponse;
 

--- a/tests/iac.e2e.test.ts
+++ b/tests/iac.e2e.test.ts
@@ -2,13 +2,15 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { diffGraphs, project, service, StaleEnvironmentError } from "../src/index.js";
+import { IacClient } from "../src/iac/client.js";
+import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { runRailwayIac, type RailwayIacCurrentResponse } from "../src/iac/runner.js";
 
 /**
- * Live IaC test: runs whenever IAC_E2E_API_TOKEN + IAC_E2E_ENVIRONMENT_ID are set
- * (loaded from .env by `mise run test`); skips otherwise so the unit suite stays
- * offline. Read-only — it exercises the `current` path against the real backboard
- * and asserts the configEtag handshake field comes back populated. No mutations.
+ * Live IaC tests: run whenever IAC_E2E_API_TOKEN + IAC_E2E_ENVIRONMENT_ID are set
+ * (loaded from .env by `mise run test`); skip otherwise so the unit suite stays
+ * offline. Safe to run unattended — read-only or rejected before any mutation.
  *
  * These use a dedicated IAC_E2E_* namespace on purpose: the RAILWAY_* names are
  * auto-injected by the platform (e.g. RAILWAY_ENVIRONMENT_ID), so a runner hosted
@@ -18,21 +20,57 @@ const live = Boolean(process.env.IAC_E2E_API_TOKEN) && Boolean(process.env.IAC_E
 
 const fixture = fileURLToPath(new URL("./fixtures/iac-apply/.railway/railway.ts", import.meta.url));
 
+const backboard = () => ({
+  token: process.env.IAC_E2E_API_TOKEN!,
+  environmentId: process.env.IAC_E2E_ENVIRONMENT_ID!,
+  ...(process.env.IAC_E2E_AUTH_TYPE === "project-token" ? { authType: "project-token" as const } : {}),
+  ...(process.env.IAC_E2E_GRAPHQL_ENDPOINT ? { endpoint: process.env.IAC_E2E_GRAPHQL_ENDPOINT } : {}),
+});
+
+const clientFor = (bb: ReturnType<typeof backboard>) =>
+  new IacClient({
+    token: bb.token,
+    ...(bb.authType ? { authType: bb.authType } : {}),
+    ...(bb.endpoint ? { graphqlEndpoint: bb.endpoint } : {}),
+  });
+
 describe.skipIf(!live)("IaC live — configEtag", () => {
   it("fetches a non-empty configEtag from the real environment", async () => {
     const result = (await runRailwayIac({
       command: "current",
       file: fixture,
-      backboard: {
-        token: process.env.IAC_E2E_API_TOKEN!,
-        environmentId: process.env.IAC_E2E_ENVIRONMENT_ID!,
-        ...(process.env.IAC_E2E_AUTH_TYPE === "project-token" ? { authType: "project-token" as const } : {}),
-        ...(process.env.IAC_E2E_GRAPHQL_ENDPOINT ? { endpoint: process.env.IAC_E2E_GRAPHQL_ENDPOINT } : {}),
-      },
+      backboard: backboard(),
     })) as RailwayIacCurrentResponse;
 
     expect(result.diagnostics.filter(d => d.severity === "error")).toEqual([]);
     expect(result.currentEnvironment?.configEtag).toEqual(expect.any(String));
     expect((result.currentEnvironment?.configEtag ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("rejects an apply whose base etag is stale, without mutating", async () => {
+    const bb = backboard();
+    const client = clientFor(bb);
+
+    // A guaranteed-non-empty changeset (a single create). Its content is
+    // irrelevant: the server's compare-and-swap runs before any side effect, so
+    // a stale base etag is refused and nothing is created.
+    const probe = "iac-e2e-stale-probe";
+    const changeSet = diffGraphs({
+      current: projectDefinitionToGraph(project("iac-e2e", { resources: [] })),
+      desired: projectDefinitionToGraph(project("iac-e2e", { resources: [service(probe, {})] })),
+    });
+    expect(changeSet.changes.length).toBeGreaterThan(0);
+
+    await expect(
+      client.applyChangeSet({ environmentId: bb.environmentId, changeSet, baseEtag: "stale-not-the-real-etag" }),
+    ).rejects.toBeInstanceOf(StaleEnvironmentError);
+
+    // The probe must not exist — the rejection happened before any mutation.
+    const after = (await runRailwayIac({
+      command: "current",
+      file: fixture,
+      backboard: bb,
+    })) as RailwayIacCurrentResponse;
+    expect(Object.values(after.currentEnvironment?.serviceNamesById ?? {})).not.toContain(probe);
   });
 });


### PR DESCRIPTION
Gives the repo its own `.railway/railway.ts` (dogfooding IaC by provisioning the live e2e runner with the IaC SDK), and fixes a namespace collision in the live suite.

## 1. `.railway/railway.ts` — dogfood e2e runner
A single cron `function`: this repo as source, `pnpm exec vitest run tests/*.e2e.test.ts`, nightly `0 7 * * *`, secrets `preserve()`d. Deploy into a **dedicated** runner project (not the e2e throwaway). Evaluated clean (`evaluate` → single function, cron, 0 diagnostics).

## 2. Dedicated `IAC_E2E_*` env namespace
`RAILWAY_*` names are **auto-injected by the platform** (notably `RAILWAY_ENVIRONMENT_ID`), so a Railway-hosted runner would read *its own* environment id instead of the e2e target — silently testing the wrong place. Both the live test and the runner config now use `IAC_E2E_API_TOKEN` / `IAC_E2E_ENVIRONMENT_ID` / `IAC_E2E_AUTH_TYPE` / `IAC_E2E_GRAPHQL_ENDPOINT`.

Validated: typecheck clean; live suite gates+skips on the new names offline; config evaluates clean.