### PR TITLE
fix(iac): redact variable values in plan output

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -401,16 +401,22 @@ function marker(change: RailwayChange): string {
   return "~";
 }
 
+// Variable values can be secrets, and plan output goes to terminals and CI logs.
+// We never render a concrete value: the change (set/update) and any non-secret
+// pointers (references, shared, preserve) are shown, but literal/raw values are
+// redacted. The structured change still carries the real value for apply.
+const REDACTED_VARIABLE_VALUE = "«hidden»";
+
 function formatVariableDiffValue(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>): string {
   if (value === undefined) return "unset";
   if (value.type === "preserve") return "preserve()";
-  if (value.type === "literal") return formatDiffValue(value.value);
   if (value.type === "reference") {
     const name = resourcesByAddress.get(value.resource)?.name ?? value.resource.split(".").slice(1).join(".") ?? value.resource;
     return `${name}.${value.output}`;
   }
   if (value.type === "sharedReference") return `shared.${value.name}`;
-  return formatDiffValue(normalizeVariableForDiff(value, resourcesByAddress));
+  // literal or raw — a concrete, possibly-secret value: never print it.
+  return REDACTED_VARIABLE_VALUE;
 }
 
 function normalizeVariableForDiff(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>): unknown {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, github, graphToEnvironmentConfig, image, postgres, project, service } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
-import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS } from "../src/iac/change-set.js";
+import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { preserve } from "../src/iac/sdk.js";
 
 describe("Railway IaC", () => {
@@ -119,6 +119,26 @@ describe("Railway IaC", () => {
 
     const varChanges = diffGraphs({ current, desired }).changes.filter(change => change.kind.startsWith("variable"));
     expect(varChanges).toEqual([]);
+  });
+
+  it("redacts variable values in plan output but keeps them in the change", () => {
+    const SECRET = "sk-super-secret-value-123";
+    const current = environmentConfigToGraph({ services: { web: { source: { repo: "r" } } } }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("r"), env: { API_KEY: SECRET } })],
+    }));
+
+    const changeSet = diffGraphs({ current, desired });
+    const change = changeSet.changes.find((c): c is SetVariableChange => c.kind === "variable.set" && c.variable === "API_KEY");
+
+    // Human-facing output (rendered diff + per-change details/summary) must never leak the value.
+    const rendered = JSON.stringify({ diff: renderChangeSet(changeSet), summary: change?.summary, details: change?.details });
+    expect(rendered).not.toContain(SECRET);
+    expect(change?.details?.[0]).toContain("API_KEY");
+    expect(change?.details?.[0]).toContain("«hidden»");
+
+    // The structured change still carries the real value so apply works.
+    expect(change?.after).toMatchObject({ type: "literal", value: SECRET });
   });
 
   it("refuses to manage a service still owned by railway.json/toml", () => {


### PR DESCRIPTION
Item 4 of the IaC GA hardening (secret redaction). Closes a real leak: `railway config plan` printed every variable's literal value to the terminal/CI logs.

## The leak
The CLI's `print_change` prints each change's `details` unconditionally, and the engine built those details with the actual value:
```
web.API_KEY (unset → "sk-super-secret-value-123")
```
Anything you put as a literal in `railway.ts` (a committed secret, an API key) ended up in plan output — and in CI logs.

## Fix (engine-side, one place)
`formatVariableDiffValue` no longer renders a concrete value. It still shows the variable and that it's changing, plus **non-secret pointers** (`svc.VAR` references, `shared.X`, `preserve()`), but literal/raw values become `«hidden»`:
```
web.API_KEY (unset → «hidden»)
```
The **structured change keeps the real value** (`after: { type: "literal", value: … }`), so apply is unaffected. Fixing it in the engine covers every consumer — the CLI just prints what the engine hands it, so no CLI change is needed.

## Validation
- New test: a secret literal never appears in the rendered diff / summary / details, but is still present in the change's `after`.
- `mise run check` — typecheck + full offline suite green (136 passed).

## Note on the other half of item 4
The **destructive-apply gate already exists** in the CLI as `--confirm-destructive` (`guard_destructive_apply` bails under `--yes`/`--json`/agent unless set) — that's the "fail closed, orthogonal to --yes" behavior, already shipped. No change needed.

## Deliberately out of scope (follow-ups)
- `railway config plan --json` still serializes the raw changeset (machine output); redacting it is a separate product call since tooling may expect values.
- A `--show-values` / `revealValues` opt-in to print non-secret values when wanted.
- Docs note that plan output redacts values by default.