### PR TITLE
feat(iac): --show-values opt-in to reveal variable values

### DIFF
--- a/src/iac/bin.ts
+++ b/src/iac/bin.ts
@@ -91,6 +91,9 @@ function setBooleanFlag(
     case "--decrypt-variables":
       backboard.decryptVariables = true;
       return true;
+    case "--show-values":
+      parsed.revealValues = true;
+      return true;
     case "--replace":
       backboard.merge = false;
       return true;

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -85,7 +85,7 @@ export interface ChangeDiagnostic {
   message: string;
 }
 
-export function diffGraphs({ current, desired }: { current: RailwayGraph; desired: RailwayGraph }): RailwayChangeSet {
+export function diffGraphs({ current, desired, revealValues = false }: { current: RailwayGraph; desired: RailwayGraph; revealValues?: boolean }): RailwayChangeSet {
   const changes: RailwayChange[] = [];
   const diagnostics: ChangeDiagnostic[] = [];
   const currentByAddress = new Map(current.resources.map(resource => [resource.address, resource]));
@@ -118,7 +118,7 @@ export function diffGraphs({ current, desired }: { current: RailwayGraph; desire
       changes.push(update(resource.address, "name", previous.name, resource.name, `Rename ${resource.type} ${previous.name} to ${resource.name}`));
     }
 
-    diffVariables({ previous, resource, changes, resourcesByAddress: desiredByAddress });
+    diffVariables({ previous, resource, changes, resourcesByAddress: desiredByAddress, revealValues });
     diffTopLevelField({ previous, resource, field: "source", changes });
     diffTopLevelField({ previous, resource, field: "build", changes });
     if (previous.type === "database" && resource.type === "database" && databaseRegion(previous) !== databaseRegion(resource)) {
@@ -249,7 +249,7 @@ export function renderChangeSet(changeSet: RailwayChangeSet): string {
   return changeSet.changes.map(change => `${marker(change)} ${change.summary}`).join("\n");
 }
 
-function diffVariables({ previous, resource, changes, resourcesByAddress }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[]; resourcesByAddress: Map<ResourceAddress, ResourceNode> }) {
+function diffVariables({ previous, resource, changes, resourcesByAddress, revealValues }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[]; resourcesByAddress: Map<ResourceAddress, ResourceNode>; revealValues: boolean }) {
   if (!("variables" in previous) && !("variables" in resource)) return;
   const before = "variables" in previous ? previous.variables ?? {} : {};
   const after = "variables" in resource ? resource.variables ?? {} : {};
@@ -264,7 +264,7 @@ function diffVariables({ previous, resource, changes, resourcesByAddress }: { pr
       after: value,
       path: `resources.${resource.address}.variables.${key}`,
       summary: `${before[key] ? "Update" : "Set"} variable ${resource.name}.${key}`,
-      details: [`${resource.name}.${key} (${formatVariableDiffValue(before[key], resourcesByAddress)} → ${formatVariableDiffValue(value, resourcesByAddress)})`],
+      details: [`${resource.name}.${key} (${formatVariableDiffValue(before[key], resourcesByAddress, revealValues)} → ${formatVariableDiffValue(value, resourcesByAddress, revealValues)})`],
       severity: "safe",
       deployEffect: "deploy",
     });
@@ -402,12 +402,13 @@ function marker(change: RailwayChange): string {
 }
 
 // Variable values can be secrets, and plan output goes to terminals and CI logs.
-// We never render a concrete value: the change (set/update) and any non-secret
-// pointers (references, shared, preserve) are shown, but literal/raw values are
-// redacted. The structured change still carries the real value for apply.
+// By default we never render a concrete value: the change (set/update) and any
+// non-secret pointers (references, shared, preserve) are shown, but literal/raw
+// values are redacted. `revealValues` (the --show-values opt-in) prints them.
+// The structured change always carries the real value for apply.
 const REDACTED_VARIABLE_VALUE = "«hidden»";
 
-function formatVariableDiffValue(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>): string {
+function formatVariableDiffValue(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>, revealValues: boolean): string {
   if (value === undefined) return "unset";
   if (value.type === "preserve") return "preserve()";
   if (value.type === "reference") {
@@ -415,8 +416,9 @@ function formatVariableDiffValue(value: VariableValue | undefined, resourcesByAd
     return `${name}.${value.output}`;
   }
   if (value.type === "sharedReference") return `shared.${value.name}`;
-  // literal or raw — a concrete, possibly-secret value: never print it.
-  return REDACTED_VARIABLE_VALUE;
+  // literal or raw — a concrete, possibly-secret value: redacted unless revealed.
+  if (!revealValues) return REDACTED_VARIABLE_VALUE;
+  return value.type === "literal" ? formatDiffValue(value.value) : formatDiffValue(normalizeVariableForDiff(value, resourcesByAddress));
 }
 
 function normalizeVariableForDiff(value: VariableValue | undefined, resourcesByAddress: Map<ResourceAddress, ResourceNode>): unknown {

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -14,6 +14,8 @@ export interface RailwayIacRunnerRequest {
   file?: string;
   includeTypes?: boolean;
   pretty?: boolean;
+  /** Print literal variable values in the plan diff instead of redacting them (--show-values). */
+  revealValues?: boolean;
   context?: RailwayContextInput;
   backboard?: RailwayIacBackboardContext;
 }
@@ -183,7 +185,7 @@ async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics 
   const client = new IacClient(clientConfig(context));
   const current = await readCurrentEnvironment(client, context);
   const currentGraph = graphFromCurrentEnvironment(current, desiredGraph);
-  const changeSet = diffGraphs({ current: currentGraph, desired: desiredGraph });
+  const changeSet = diffGraphs({ current: currentGraph, desired: desiredGraph, revealValues: request.revealValues ?? false });
   const allDiagnostics = [...diagnostics, ...changeSetDiagnostics(changeSet)];
   const { config: _config, ...currentEnvironment } = current;
   const hasErrors = !hasNoErrors(allDiagnostics);

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -141,6 +141,20 @@ describe("Railway IaC", () => {
     expect(change?.after).toMatchObject({ type: "literal", value: SECRET });
   });
 
+  it("reveals variable values when revealValues is set (--show-values)", () => {
+    const SECRET = "sk-super-secret-value-123";
+    const current = environmentConfigToGraph({ services: { web: { source: { repo: "r" } } } }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("r"), env: { API_KEY: SECRET } })],
+    }));
+
+    const changeSet = diffGraphs({ current, desired, revealValues: true });
+    const change = changeSet.changes.find((c): c is SetVariableChange => c.kind === "variable.set" && c.variable === "API_KEY");
+
+    expect(change?.details?.[0]).toContain(SECRET);
+    expect(change?.details?.[0]).not.toContain("«hidden»");
+  });
+
   it("refuses to manage a service still owned by railway.json/toml", () => {
     const current = environmentConfigToGraph({
       services: { web: { source: { repo: "r" }, configFile: "railway.json" } },


### PR DESCRIPTION
The opt-in counterpart to plan-output redaction (**stacked on #32** — merge that first; GitHub will retarget this to `main`).

Redaction hides literal variable values by default. Sometimes you're tuning a *non-secret* config var and want to see what it's changing to — `revealValues` turns the redaction off for that run:

```
# default (redacted)
web.API_KEY (unset → «hidden»)
# with --show-values
web.API_KEY (unset → "sk-...")
```

Threaded `diffGraphs({ revealValues })` → runner request `revealValues` → `bin --show-values`. Default stays redacted; references/shared/preserve render the same either way; the structured change always carried the real value. CLI `--show-values` flag is a separate PR in railwayapp/cli.

Tests: redaction (default) + reveal both asserted. `mise run check` green (137 passed).