### PR TITLE
Add IaC volume support

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -1,5 +1,5 @@
 import { composePatch, graphToEnvironmentConfig } from "./compiler.js";
-import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, VariableValue } from "./graph.js";
+import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, VariableValue, VolumeNode } from "./graph.js";
 import type { EnvironmentConfig } from "./schema.js";
 
 // Wire-contract version for the RailwayChangeSet exchanged with backboard.
@@ -136,9 +136,12 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
         path: `resources.${resource.address}.config.region`,
         message: `Bucket region cannot be changed after creation. Create a new bucket in ${bucketRegion(resource) ?? "the desired region"} and migrate data instead.`,
       });
+    } else if (previous.type === "volume" && resource.type === "volume") {
+      diffVolumeConfig({ previous, resource, changes });
     } else {
       diffTopLevelField({ previous, resource, field: "config", changes });
     }
+    diffVolumeAttachments({ previous, resource, changes });
     // Database mount paths are product/template defaults in v0. Do not churn or attempt
     // mount-path updates after creation; Backboard owns the database realization details.
   }
@@ -303,6 +306,16 @@ function diffNetworking({ previous, resource, changes }: { previous: ResourceNod
   }
 }
 
+function diffVolumeAttachments({ previous, resource, changes }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[] }) {
+  const before = (previous as { volumeAttachments?: unknown }).volumeAttachments;
+  const after = (resource as { volumeAttachments?: unknown }).volumeAttachments;
+  const normalizedBefore = normalizeForDiff("volumeAttachments", before);
+  const normalizedAfter = normalizeForDiff("volumeAttachments", after);
+  if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
+  const destructive = Object.keys((before as Record<string, unknown> | undefined) ?? {}).some(key => !(key in ((after as Record<string, unknown> | undefined) ?? {})));
+  changes.push(update(resource.address, "volumeAttachments", before, after, summaryForField(resource, "volumeAttachments", normalizedBefore, normalizedAfter), changedLeafPaths(normalizedBefore, normalizedAfter, "volumeAttachments"), destructive ? "destructive" : "safe"));
+}
+
 function diffTopLevelField({ previous, resource, field, changes }: { previous: ResourceNode; resource: ResourceNode; field: string; changes: RailwayChange[] }) {
   const before = (previous as unknown as Record<string, unknown>)[field];
   const after = (resource as unknown as Record<string, unknown>)[field];
@@ -318,6 +331,19 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
 // authoring helpers never reproduce. Diff only what the user can actually author — an explicit
 // region pin — so we never plan an accidental unmount or a churn "move to default region" for a
 // database that simply didn't pin one.
+function diffVolumeConfig({ previous, resource, changes }: { previous: VolumeNode; resource: VolumeNode; changes: RailwayChange[] }) {
+  const before = normalizeForDiff("config", previous.config);
+  const after = normalizeForDiff("config", resource.config);
+  if (stableStringify(before) === stableStringify(after)) return;
+  const previousSize = previous.config?.sizeMB;
+  const desiredSize = resource.config?.sizeMB;
+  const severity = previous.config?.region !== resource.config?.region || (typeof previousSize === "number" && typeof desiredSize === "number" && desiredSize < previousSize) ? "destructive" : "safe";
+  const summary = typeof previousSize === "number" && typeof desiredSize === "number" && desiredSize > previousSize
+    ? `Resize volume ${resource.name} from ${previousSize}MB to ${desiredSize}MB`
+    : summaryForField(resource, "config", before, after);
+  changes.push(update(resource.address, "config", previous.config, resource.config, summary, changedLeafPaths(before, after, "config"), severity));
+}
+
 function diffDatabaseDeploy({ previous, resource, changes }: { previous: DatabaseNode; resource: DatabaseNode; changes: RailwayChange[] }) {
   const previousRegion = databaseRegion(previous);
   const desiredRegion = databaseRegion(resource);

--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -3,11 +3,7 @@ import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { normalizeRailwayClientConfig, type RailwayClientConfig, type NormalizedRailwayClientConfig } from "../core/config.js";
 import { requestGraphQL } from "../core/graphql-client.js";
 import { RailwayGraphQLError, StaleEnvironmentError, STALE_ENVIRONMENT_BASE_CODE } from "../core/errors.js";
-import type {
-  BucketCreateInput,
-  ServiceCreateInput,
-  VolumeCreateInput,
-} from "../generated/graphql.js";
+import type { BucketCreateInput, ServiceCreateInput, VolumeCreateInput } from "../generated/graphql.js";
 import type { RailwayChangeSet } from "./change-set.js";
 import type { RailwayGraph, ResourceNode } from "./graph.js";
 import type { EnvironmentConfig } from "./schema.js";
@@ -21,6 +17,7 @@ export interface CurrentEnvironmentResult {
   /** Opaque snapshot token of the environment config the plan was computed against. */
   configEtag?: string | undefined;
   serviceNamesById: Record<string, string>;
+  volumeNamesById: Record<string, string>;
   bucketNamesById: Record<string, string>;
   customDomainsByServiceId: Record<string, Record<string, { port?: number }>>;
 }
@@ -81,6 +78,7 @@ export class IacClient {
 
     const projectName = data.environment.projectId ? await this.getProjectName(data.environment.projectId) : undefined;
     const services = data.environment.projectId ? await this.getProjectServices(data.environment.projectId) : [];
+    const volumes = data.environment.projectId ? await this.getProjectVolumes(data.environment.projectId) : [];
     const buckets = data.environment.projectId ? await this.getProjectBuckets(data.environment.projectId) : [];
     const customDomainsByServiceId = data.environment.projectId ? await this.getEnvironmentCustomDomains(data.environment.projectId, environmentId, services) : {};
     return {
@@ -90,6 +88,7 @@ export class IacClient {
       environmentName: data.environment.name,
       config: data.environment.config ?? {},
       serviceNamesById: Object.fromEntries(services.map(service => [service.id, service.name])),
+      volumeNamesById: Object.fromEntries(volumes.flatMap(volume => volume.name ? [[volume.id, volume.name] as const] : [])),
       bucketNamesById: Object.fromEntries(buckets.map(bucket => [bucket.id, bucket.name])),
       customDomainsByServiceId,
       ...(data.environment.configEtag ? { configEtag: data.environment.configEtag } : {}),
@@ -115,6 +114,13 @@ export class IacClient {
       project(id: $projectId) { services(first: 1000) { edges { node { id name } } } }
     }`, { projectId });
     return data.project.services.edges.map(edge => edge.node);
+  }
+
+  async getProjectVolumes(projectId: string): Promise<ProjectVolume[]> {
+    const data = await gql<{ project: { volumes: { edges: Array<{ node: ProjectVolume }> } } }, { projectId: string }>(this.#config, `query IacProjectVolumes($projectId: String!) {
+      project(id: $projectId) { volumes(first: 1000) { edges { node { id name } } } }
+    }`, { projectId });
+    return data.project.volumes?.edges.map(edge => edge.node) ?? [];
   }
 
   async getProjectBuckets(projectId: string): Promise<ProjectBucket[]> {

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -12,10 +12,23 @@ import type {
 import type { DeployConfig, EnvironmentConfig, ServiceConfig, ServiceNetworking, VariableConfig, VariableValues } from "./schema.js";
 
 export function projectDefinitionToGraph(definition: ProjectDefinition): RailwayGraph {
-  const resources = (definition.resources ?? definition.services ?? []).flat();
+  const resources = [...(definition.resources ?? definition.services ?? []).flat()];
+  const resourcesByAddress = new Set(resources.map(resource => resource.address));
+  for (const resource of [...resources]) {
+    if (resource.type !== "service" && resource.type !== "database") continue;
+    for (const attachment of Object.values(resource.volumeAttachments ?? {})) {
+      if (resourcesByAddress.has(attachment.volume)) continue;
+      const volumeName = attachment.volume.split(".").slice(1).join(".");
+      resources.push({ address: attachment.volume as `volume.${string}`, type: "volume", name: volumeName });
+      resourcesByAddress.add(attachment.volume);
+    }
+  }
   const edges: Edge[] = [];
   for (const resource of resources) {
     if (resource.type !== "service" && resource.type !== "database") continue;
+    for (const attachment of Object.values(resource.volumeAttachments ?? {})) {
+      edges.push({ from: resource.address, to: attachment.volume as Edge["to"], type: "mount", key: attachment.mountPath });
+    }
     for (const [key, value] of Object.entries(resource.variables ?? {})) {
       if (value.type !== "reference") continue;
       edges.push({ from: resource.address, to: value.resource as Edge["to"], type: "variable", key });
@@ -58,6 +71,7 @@ export function graphToEnvironmentConfig(graph: RailwayGraph, options: GraphComp
             })
           : serviceToEnvironmentConfig(resource, resourceNamesById, {
               isNew: !existingServiceIds.has(serviceKey),
+              volumeIdsByName: options.volumeIdsByName ?? {},
             });
 
       const volumeId = options.volumeIdsByServiceName?.[resource.name];
@@ -71,7 +85,8 @@ export function graphToEnvironmentConfig(graph: RailwayGraph, options: GraphComp
 
     if (resource.type === "volume") {
       config.volumes = config.volumes ?? {};
-      config.volumes[resource.name] = { isCreated: true, ...resource.config };
+      const existingVolumeId = options.volumeIdsByName?.[resource.name];
+      config.volumes[existingVolumeId ?? resource.name] = { ...(existingVolumeId ? {} : { isCreated: true }), ...resource.config };
       continue;
     }
 
@@ -100,7 +115,7 @@ export function graphToEnvironmentConfig(graph: RailwayGraph, options: GraphComp
 
 export function environmentConfigToGraph(
   config: EnvironmentConfig,
-  options: { projectName?: string; serviceNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
+  options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
 ): RailwayGraph {
   const resources: ResourceNode[] = [];
   const groupNamesById = Object.fromEntries(
@@ -154,9 +169,20 @@ export function environmentConfigToGraph(
       ...(serviceConfig.deploy ? { deploy: serviceConfig.deploy } : {}),
       ...(serviceConfig.variables ? { variables: variablesFromEnvironmentConfig(serviceConfig.variables) } : {}),
       ...(serviceConfig.networking || options.customDomainsByServiceId?.[serviceId] ? { networking: pruneEmpty({ ...serviceConfig.networking, customDomains: options.customDomainsByServiceId?.[serviceId] ?? serviceConfig.networking?.customDomains }) as ServiceNetworking } : {}),
-      ...(serviceConfig.volumeMounts ? { volumeMounts: serviceConfig.volumeMounts } : {}),
+      ...volumeAttachmentsFromEnvironmentConfig(serviceConfig.volumeMounts, options.volumeNamesById),
       ...(serviceConfig.configFile ? { configFile: serviceConfig.configFile } : {}),
       ...(serviceConfig.groupId ? { groupId: groupNamesById[serviceConfig.groupId] ?? serviceConfig.groupId } : {}),
+    });
+  }
+
+  for (const [volumeId, volumeConfig] of Object.entries(config.volumes ?? {})) {
+    if (volumeConfig == null || volumeConfig.isDeleted) continue;
+    const name = options.volumeNamesById?.[volumeId] ?? volumeId;
+    resources.push({
+      address: resourceAddress("volume", name) as `volume.${string}`,
+      type: "volume",
+      name,
+      config: volumeConfig,
     });
   }
 
@@ -185,6 +211,13 @@ export function composePatch({ currentConfig, desiredConfig }: { currentConfig: 
 
 function addDeletionMarkers({ currentConfig, desiredConfig }: { currentConfig: EnvironmentConfig; desiredConfig: EnvironmentConfig }): EnvironmentConfig {
   const next: EnvironmentConfig = structuredClone(desiredConfig);
+  for (const [volumeId, currentVolume] of Object.entries(currentConfig.volumes ?? {})) {
+    if (currentVolume == null || currentVolume.isDeleted) continue;
+    if (desiredConfig.volumes?.[volumeId] != null) continue;
+    next.volumes = next.volumes ?? {};
+    next.volumes[volumeId] = { isDeleted: true };
+  }
+
   for (const [serviceId, currentService] of Object.entries(currentConfig.services ?? {})) {
     if (currentService == null || currentService.isDeleted) continue;
     const desiredService = desiredConfig.services?.[serviceId];
@@ -251,7 +284,7 @@ function databaseToEnvironmentConfig(database: DatabaseNode, options: { isNew: b
   });
 }
 
-function serviceToEnvironmentConfig(service: ServiceNode, resourceNamesById: Record<string, string>, options: { isNew: boolean }): ServiceConfig {
+function serviceToEnvironmentConfig(service: ServiceNode, resourceNamesById: Record<string, string>, options: { isNew: boolean; volumeIdsByName?: Record<string, string> }): ServiceConfig {
   const config: ServiceConfig = { ...(options.isNew ? { isCreated: true } : {}) };
   if (service.source) {
     const source = pruneEmpty({
@@ -270,7 +303,14 @@ function serviceToEnvironmentConfig(service: ServiceNode, resourceNamesById: Rec
   if (service.deploy) config.deploy = service.deploy;
   if (service.variables) config.variables = variablesToEnvironmentConfig(service.variables, resourceNamesById);
   if (service.networking) config.networking = service.networking;
-  if (service.volumeMounts) config.volumeMounts = service.volumeMounts;
+  const attachedVolumeMounts = Object.fromEntries(
+    Object.entries(service.volumeAttachments ?? {}).map(([, attachment]) => {
+      const volumeName = resourceNamesById[attachment.volume] ?? attachment.volume.split(".").slice(1).join(".");
+      const volumeId = options.volumeIdsByName?.[volumeName] ?? volumeName;
+      return [volumeId, pruneEmpty({ mountPath: attachment.mountPath, ...(attachment.backupSchedules ? { backupSchedules: attachment.backupSchedules } : {}) })];
+    }),
+  );
+  if (service.volumeMounts || Object.keys(attachedVolumeMounts).length > 0) config.volumeMounts = { ...(service.volumeMounts ?? {}), ...attachedVolumeMounts };
   if (service.configFile) config.configFile = service.configFile;
   if (service.parentServiceId) config.parentServiceId = service.parentServiceId;
   if (service.groupId) config.groupId = service.groupId;
@@ -302,6 +342,17 @@ function sharedReferenceVariable(value: Extract<VariableValue, { type: "sharedRe
 function literalVariable(value: Extract<VariableValue, { type: "literal" }>): VariableConfig {
   const { type: _type, ...variable } = value;
   return variable;
+}
+
+function volumeAttachmentsFromEnvironmentConfig(volumeMounts: ServiceConfig["volumeMounts"], volumeNamesById: Record<string, string> = {}): Pick<ServiceNode, "volumeAttachments"> {
+  const attachments = Object.fromEntries(
+    Object.entries(volumeMounts ?? {}).flatMap(([volumeId, mount]) => {
+      if (!mount?.mountPath) return [];
+      const name = volumeNamesById[volumeId] ?? volumeId;
+      return [[name, { volume: resourceAddress("volume", name), mountPath: mount.mountPath, ...(mount.backupSchedules ? { backupSchedules: mount.backupSchedules } : {}) }]];
+    }),
+  );
+  return Object.keys(attachments).length > 0 ? { volumeAttachments: attachments as NonNullable<ServiceNode["volumeAttachments"]> } : {};
 }
 
 function variablesFromEnvironmentConfig(variables: VariableValues): Record<string, VariableValue> {

--- a/src/iac/graph.ts
+++ b/src/iac/graph.ts
@@ -62,6 +62,7 @@ export interface ServiceNode extends GraphResourceBase {
   networking?: ServiceNetworking;
   variables?: Record<string, VariableValue>;
   volumeMounts?: Record<string, VolumeMount | null>;
+  volumeAttachments?: Record<string, { volume: ResourceAddress; mountPath: string; backupSchedules?: VolumeMount["backupSchedules"] }>;
   configFile?: string;
   parentServiceId?: string;
   groupId?: string;
@@ -128,6 +129,7 @@ export interface GraphCompileOptions {
   serviceIdsByName?: Record<string, string>;
   existingServiceIds?: string[];
   volumeIdsByServiceName?: Record<string, string>;
+  volumeIdsByName?: Record<string, string>;
   bucketIdsByName?: Record<string, string>;
 }
 

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -258,6 +258,7 @@ function graphFromCurrentEnvironment(current: CurrentEnvironmentResult, desiredG
   return environmentConfigToGraph(current.config, {
     projectName: current.projectName ?? desiredGraph.project.name,
     serviceNamesById: current.serviceNamesById,
+    volumeNamesById: current.volumeNamesById,
     bucketNamesById: current.bucketNamesById,
     customDomainsByServiceId: current.customDomainsByServiceId,
   });

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -90,7 +90,7 @@ export interface IntentServiceConfig {
   tcpProxies?: string[];
   env?: Record<string, string | VariableConfig | VariableValue>;
   variables?: Record<string, string | VariableConfig | VariableValue>;
-  volumeMounts?: Record<string, VolumeMount | null>;
+  volumeMounts?: Record<string, VolumeMount | null | VolumeNode>;
   configFile?: string;
   parentServiceId?: string;
   groupId?: string;
@@ -155,7 +155,7 @@ export function service<const Env extends Record<string, string | VariableConfig
     deploy: normalizeDeploy(config),
     networking: normalizeNetworking(config),
     ...(config.env || config.variables ? { variables: normalizeVariables({ ...(config.variables ?? {}), ...(config.env ?? {}) }) } : {}),
-    ...(config.volumeMounts ? { volumeMounts: config.volumeMounts } : {}),
+    ...normalizeVolumeMounts(config.volumeMounts),
     ...(config.configFile ? { configFile: config.configFile } : {}),
     ...(config.parentServiceId ? { parentServiceId: config.parentServiceId } : {}),
     ...(config.groupId ? { groupId: config.groupId } : {}),
@@ -340,6 +340,20 @@ function normalizeVariables(variables: Record<string, string | VariableConfig | 
       return [key, { type: "raw", value }];
     }),
   );
+}
+
+function normalizeVolumeMounts(volumeMounts: ServiceConfigInput["volumeMounts"]): Pick<ServiceNode, "volumeMounts" | "volumeAttachments"> {
+  if (!volumeMounts) return {};
+  const rawMounts: ServiceNode["volumeMounts"] = {};
+  const attachments: NonNullable<ServiceNode["volumeAttachments"]> = {};
+  for (const [key, value] of Object.entries(volumeMounts)) {
+    if (value && typeof value === "object" && "type" in value && value.type === "volume") {
+      attachments[value.name] = { volume: value.address, mountPath: key };
+      continue;
+    }
+    rawMounts[key] = value as VolumeMount | null;
+  }
+  return pruneEmpty({ volumeMounts: rawMounts, volumeAttachments: attachments }) ?? {};
 }
 
 function pruneEmpty<T>(value: T): T | undefined {

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -68,6 +68,7 @@ describe("IaC apply — configEtag handshake", () => {
       { data: { environment: { id: "e1", name: "production", projectId: "p1", config: {}, configEtag: "etag-abc" } } },
       { data: { project: { name: "proj" } } },
       { data: { project: { services: { edges: [] } } } },
+      { data: { project: { volumes: { edges: [] } } } },
       { data: { project: { buckets: { edges: [] } } } },
     ]);
 
@@ -83,11 +84,12 @@ describe("IaC runner — threads configEtag from plan into apply", () => {
   const fixture = fileURLToPath(new URL("./fixtures/iac-apply/.railway/railway.ts", import.meta.url));
 
   it("captures configEtag during plan and sends it as baseConfigEtag on apply", async () => {
-    // Ordered responses for: env config, project name, services, buckets, preview, apply.
+    // Ordered responses for: env config, project name, services, volumes, buckets, preview, apply.
     const mock = createFetchMock([
       { data: { environment: { id: "e1", name: "production", projectId: "p1", config: {}, configEtag: "etag-LIVE" } } },
       { data: { project: { name: "e2e-thread" } } },
       { data: { project: { services: { edges: [] } } } },
+      { data: { project: { volumes: { edges: [] } } } },
       { data: { project: { buckets: { edges: [] } } } },
       { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [], diagnostics: [] }, diagnostics: [], effects: [] } } },
       { data: { environmentApplyChangeSet: { id: "op_1", status: "applied", changes: [], diagnostics: [], deploymentId: "deploy_1", stagedPatchId: null } } },

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, github, graphToEnvironmentConfig, image, postgres, project, service } from "../src/index.js";
+import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, github, graphToEnvironmentConfig, image, postgres, project, service, volume } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { preserve } from "../src/iac/sdk.js";
@@ -15,6 +15,31 @@ describe("Railway IaC", () => {
     expect(diffGraphs({ current, desired }).version).toBe(1);
   });
 
+
+  it("compiles service volume attachments", () => {
+    const data = volume("web-data", { region: "us-west2", sizeMB: 1024 });
+    const graph = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { volumeMounts: { "/data": data } })],
+    }));
+
+    expect(graph.edges).toContainEqual({ from: "service.web", to: "volume.web-data", type: "mount", key: "/data" });
+    expect(graph.resources).toEqual(expect.arrayContaining([expect.objectContaining({ type: "volume", name: "web-data" })]));
+    expect(graphToEnvironmentConfig(graph, { volumeIdsByName: { "web-data": "vol-id" } }).services?.web?.volumeMounts).toEqual({
+      "vol-id": { mountPath: "/data" },
+    });
+  });
+
+  it("marks volume upsize safe and downsize destructive", () => {
+    const small = projectDefinitionToGraph(project("app", { resources: [volume("data", { sizeMB: 1024 })] }));
+    const large = projectDefinitionToGraph(project("app", { resources: [volume("data", { sizeMB: 2048 })] }));
+
+    expect(diffGraphs({ current: small, desired: large }).changes).toMatchObject([
+      { kind: "resource.update", address: "volume.data", field: "config", severity: "safe" },
+    ]);
+    expect(diffGraphs({ current: large, desired: small }).changes).toMatchObject([
+      { kind: "resource.update", address: "volume.data", field: "config", severity: "destructive" },
+    ]);
+  });
 
   it("compiles shared variable references from context", () => {
     const ctx = createRailwayContext();


### PR DESCRIPTION
Adds first-class IaC volume authoring: `volume()`, ergonomic service attachments via `volumeMounts`, import round-tripping, create/delete patching, attach/detach diffs, and safe upsize/destructive downsize planning.

Validation:
- `mise run check`
