### PR TITLE
Plan updates for unknown variable values

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -249,8 +249,8 @@ function diffVariables({ previous, resource, changes, resourcesByAddress, reveal
   const before = "variables" in previous ? previous.variables ?? {} : {};
   const after = "variables" in resource ? resource.variables ?? {} : {};
   for (const [key, value] of Object.entries(after)) {
-    if (isPreservedVariable(value) || isPreservedVariable(before[key]) || isUnknownImportedVariable(before[key])) continue;
-    if (stableStringify(normalizeVariableForDiff(before[key], resourcesByAddress)) === stableStringify(normalizeVariableForDiff(value, resourcesByAddress))) continue;
+    if (isPreservedVariable(value)) continue;
+    if (!isUnknownCurrentVariable(before[key]) && stableStringify(normalizeVariableForDiff(before[key], resourcesByAddress)) === stableStringify(normalizeVariableForDiff(value, resourcesByAddress))) continue;
     changes.push({
       kind: "variable.set",
       address: resource.address,
@@ -511,8 +511,8 @@ function isPreservedVariable(value: VariableValue | undefined): boolean {
   return value?.type === "preserve";
 }
 
-function isUnknownImportedVariable(value: VariableValue | undefined): boolean {
-  return value?.type === "literal" && value.value === "";
+function isUnknownCurrentVariable(value: VariableValue | undefined): boolean {
+  return value?.type === "preserve" || (value?.type === "literal" && value.value === "");
 }
 
 function normalizeForDiff(field: string, value: unknown): unknown {

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -193,6 +193,8 @@ async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics 
     ? await client.previewChangeSet({ environmentId: context.environmentId, changeSet })
     : undefined;
 
+  const previewedChangeSet = preview?.changeSet ?? changeSet;
+
   return {
     ok: !hasErrors,
     command: "plan",
@@ -202,9 +204,9 @@ async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics 
     desiredGraph,
     currentConfig: current.config,
     currentEnvironment,
-    changeSet,
+    changeSet: previewedChangeSet,
     ...(preview ? { preview } : {}),
-    diff: renderChangeSet(changeSet),
+    diff: renderChangeSet(previewedChangeSet),
     ...(request.includeTypes ? { graphTypes: renderRailwayGraphTypes(desiredGraph) } : {}),
     diagnostics: allDiagnostics,
   };

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -91,7 +91,7 @@ describe("IaC runner — threads configEtag from plan into apply", () => {
       { data: { project: { services: { edges: [] } } } },
       { data: { project: { volumes: { edges: [] } } } },
       { data: { project: { buckets: { edges: [] } } } },
-      { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [], diagnostics: [] }, diagnostics: [], effects: [] } } },
+      { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [{ kind: "resource.create", address: "service.web", resource: { address: "service.web", type: "service", name: "web" }, path: "resources.service.web", summary: "Create service web", severity: "safe", deployEffect: "deploy" }], diagnostics: [] }, diagnostics: [], effects: [] } } },
       { data: { environmentApplyChangeSet: { id: "op_1", status: "applied", changes: [], diagnostics: [], deploymentId: "deploy_1", stagedPatchId: null } } },
     ]);
     vi.stubGlobal("fetch", mock.fetch);

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -16,6 +16,19 @@ describe("Railway IaC", () => {
   });
 
 
+  it("plans literal variable changes when current value is unknown", () => {
+    const current = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { env: { TOKEN: preserve() } })],
+    }));
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { env: { TOKEN: "new-value" } })],
+    }));
+
+    expect(diffGraphs({ current, desired }).changes).toMatchObject([
+      { kind: "variable.set", address: "service.web", variable: "TOKEN" },
+    ]);
+  });
+
   it("compiles service volume attachments", () => {
     const data = volume("web-data", { region: "us-west2", sizeMB: 1024 });
     const graph = projectDefinitionToGraph(project("app", {


### PR DESCRIPTION
Treats authored variable values as changes when the current value is redacted/unknown, while continuing to redact plan output. Uses Backboard preview changesets for display/apply so server-side noops can be removed.