### PR TITLE
Ignore Dockerfile build defaults in IaC diffs

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -531,6 +531,8 @@ function normalizeForDiff(field: string, value: unknown): unknown {
   if (field === "build") {
     if (copy.builder === "RAILPACK") delete copy.builder;
     if (copy.buildEnvironment === "V3") delete copy.buildEnvironment;
+    if (copy.buildCommand === "") delete copy.buildCommand;
+    if (copy.dockerfilePath === "Dockerfile") delete copy.dockerfilePath;
   }
 
   if (field === "deploy") {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -29,6 +29,17 @@ describe("Railway IaC", () => {
     ]);
   });
 
+  it("does not plan Dockerfile build default drift", () => {
+    const current = projectDefinitionToGraph(project("app", {
+      resources: [service("backend", { build: { builder: "DOCKERFILE", dockerfilePath: "Dockerfile", buildCommand: "" } })],
+    }));
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("backend", { build: { builder: "DOCKERFILE" } })],
+    }));
+
+    expect(diffGraphs({ current, desired }).changes).toEqual([]);
+  });
+
   it("compiles service volume attachments", () => {
     const data = volume("web-data", { region: "us-west2", sizeMB: 1024 });
     const graph = projectDefinitionToGraph(project("app", {


### PR DESCRIPTION
Suppresses repeated IaC drift from imported Dockerfile defaults like empty buildCommand and Dockerfile dockerfilePath.