### PR TITLE
Add interactive stdin to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ const result = await sandbox.exec({ sessionName }, {
 See `examples/sandboxes/exec.ts` for detaching and reattaching by `sessionName`
 from a fresh `Sandbox.connect(id)`.
 
+By default stdin is EOF'd at start so commands that read it can finish. Pass
+`stdin: true` to keep it open and talk to the running command through
+`handle.stdin` — the duplex channel interactive processes (agent CLIs speaking
+JSON over stdio, REPLs) need. Many commands only exit after EOF, so finish with
+`stdin.end()`:
+
+```ts
+const handle = sandbox.exec("claude -p --input-format stream-json --output-format stream-json", {
+  stdin: true,
+  onStdout: chunk => process.stdout.write(chunk),
+});
+
+await handle.stdin.write(JSON.stringify(userMessage) + "\n");
+// … read the reply, then send follow-up turns down the same stdin …
+await handle.stdin.end(); // EOF — the command can now exit
+const result = await handle;
+```
+
+`stdin: true` also works on reattach: writes reach the still-running process.
+See `examples/sandboxes/stdin.ts` for a round-trip and a multi-turn
+request/response session.
+
 If the WebSocket cannot be established, `exec` rejects with
 `RailwayConnectionError`. In non-Node runtimes without a global `WebSocket`,
 pass an implementation via the `webSocketImpl` config option.

--- a/examples/sandboxes/stdin.ts
+++ b/examples/sandboxes/stdin.ts
@@ -1,0 +1,51 @@
+import { Sandbox } from "../../src/index.ts";
+import { runExample, sleep } from "./helpers.ts";
+
+// Interactive stdin: start a command with `stdin: true` to keep its stdin open,
+// write to it while it runs via `handle.stdin.write()`, and deliver EOF with
+// `handle.stdin.end()`. This is the duplex primitive interactive workloads
+// (JSON-RPC-over-stdio agents, REPLs) need — without it, a command's stdin is
+// EOF'd at start.
+await runExample(async () => {
+  const checkpoint = process.env.SANDBOX_CHECKPOINT ?? "agent-box";
+  console.log(`booting sandbox from checkpoint "${checkpoint}"…`);
+  const startedAt = Date.now();
+  await using sandbox = await Sandbox.create(checkpoint);
+  console.log(`sandbox ${sandbox.id} running (${Date.now() - startedAt}ms)\n`);
+
+  // 1) Round-trip through `cat`: bytes written to stdin come straight back on
+  //    stdout, and cat exits only once stdin is EOF'd — proving both the write
+  //    path and EOF delivery.
+  console.log("-- cat round-trip --");
+  const cat = sandbox.exec("cat", {
+    stdin: true,
+    timeoutSec: 60,
+    onStdout: chunk => process.stdout.write(`  cat> ${chunk}`),
+  });
+  await cat.stdin.write("hello over the exec websocket\n");
+  await cat.stdin.write("stdin frames are working\n");
+  await sleep(750);
+  await cat.stdin.end(); // EOF → cat exits 0
+  const catResult = await cat;
+  console.log(`  cat exited ${catResult.exitCode}\n`);
+
+  // 2) A long-lived interactive session: the process answers each request it
+  //    reads from stdin — the shape of an agent stdio dialogue, where the next
+  //    write depends on output already received.
+  console.log("-- interactive request/response session --");
+  const session = sandbox.exec(
+    'while IFS= read -r line; do echo "ack: $line"; done; echo "eof: session closed"',
+    {
+      stdin: true,
+      timeoutSec: 60,
+      onStdout: chunk => process.stdout.write(`  agent> ${chunk}`),
+    },
+  );
+  for (const request of ["initialize", "session/new", "session/prompt fix the bug"]) {
+    await session.stdin.write(`${request}\n`);
+    await sleep(500); // read the reply before sending the next request
+  }
+  await session.stdin.end();
+  const sessionResult = await session;
+  console.log(`  session exited ${sessionResult.exitCode}`);
+});

--- a/src/core/exec-ws-client.ts
+++ b/src/core/exec-ws-client.ts
@@ -11,6 +11,7 @@ import type { RailwayWsSocket } from "./ws-socket.js";
  * by a leading byte; init, stdin-EOF, and exit are JSON text frames.
  */
 const STDOUT_FRAME = 0x01;
+const STDIN_FRAME = 0x02;
 const STDERR_FRAME = 0x03;
 
 /** Subprotocol the tcp-proxy bridges expect alongside the JWT. */
@@ -32,6 +33,8 @@ export interface ExecWsHandlers {
 }
 
 export interface ExecWsConnection {
+  /** Write bytes to the command's stdin (a tagged binary frame). */
+  writeStdin(bytes: Uint8Array): void;
   /** Half-close stdin (EOF) so commands that read stdin can finish. */
   closeStdin(): void;
   /** Deliver a signal to the command's process group (e.g. "TERM", "KILL"). */
@@ -64,6 +67,7 @@ export function connectExecWs(args: {
 
   return new Promise<ExecWsConnection>((resolve, reject) => {
     let opened = false;
+    let closed = false;
     const socket = new WS(config.tcpProxyWsEndpoint, [
       SHELL_SUBPROTOCOL,
       jwt,
@@ -85,10 +89,26 @@ export function connectExecWs(args: {
       if (resumeFromLastRead) data.resume_from_last_read = true;
       socket.send(JSON.stringify({ type: "init_exec", data }));
       resolve({
+        writeStdin: bytes => {
+          // Sends on a closed socket are silently dropped by some WebSocket
+          // impls; losing stdin bytes is a correctness bug, so fail loudly.
+          if (closed) {
+            throw new RailwayConnectionError({
+              message: "stdin write after the exec socket closed.",
+            });
+          }
+          const framed = new Uint8Array(1 + bytes.byteLength);
+          framed[0] = STDIN_FRAME;
+          framed.set(bytes, 1);
+          socket.send(framed);
+        },
         closeStdin: () => socket.send(JSON.stringify({ type: "stdin_close" })),
         signal: name =>
           socket.send(JSON.stringify({ type: "signal", data: { signal: name } })),
-        close: () => socket.close(1000, ""),
+        close: () => {
+          closed = true;
+          socket.close(1000, "");
+        },
       });
     };
 
@@ -99,6 +119,7 @@ export function connectExecWs(args: {
     };
 
     socket.onclose = event => {
+      closed = true;
       if (!opened) {
         reject(
           new RailwayConnectionError({

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export {
   type ExecReattachTarget,
   type ExecResult,
   type ExecSignal,
+  type ExecStdin,
   type ExecTarget,
   type FileReadFormat,
   type FileReadOptions,

--- a/src/sandbox/exec.ts
+++ b/src/sandbox/exec.ts
@@ -22,12 +22,25 @@ const decoder = () => new TextDecoder();
  */
 const REATTACH_PLACEHOLDER_COMMAND = ":";
 
+/**
+ * Interactive stdin for a running exec, enabled with `ExecOptions.stdin: true`.
+ * Writes go to the command's process over the exec WebSocket; `end()` delivers
+ * EOF (commands like `cat` only exit after it).
+ */
+export interface ExecStdin {
+  /** Write to the command's stdin. Strings are UTF-8 encoded. */
+  write(data: string | Uint8Array): Promise<void>;
+  /** Half-close stdin (EOF) so commands that read stdin can finish. */
+  end(): Promise<void>;
+}
+
 /** Module-internal access to ExecHandle's private constructor. */
 let constructHandle: (args: {
   sessionName: Promise<string>;
   result: Promise<ExecResult>;
   kill: (signal: ExecSignal) => Promise<boolean>;
   detach: () => Promise<string>;
+  stdin: ExecStdin;
 }) => ExecHandle;
 
 /**
@@ -37,6 +50,11 @@ let constructHandle: (args: {
 export class ExecHandle implements Promise<ExecResult> {
   /** Durable session name for this exec; reattach via `exec({ sessionName })`. */
   readonly sessionName: Promise<string>;
+  /**
+   * Interactive stdin. Only live when the exec was started with
+   * `stdin: true`; otherwise `write()` rejects (stdin was EOF'd at start).
+   */
+  readonly stdin: ExecStdin;
   readonly [Symbol.toStringTag] = "ExecHandle";
   readonly #result: Promise<ExecResult>;
   readonly #kill: (signal: ExecSignal) => Promise<boolean>;
@@ -48,8 +66,10 @@ export class ExecHandle implements Promise<ExecResult> {
     result: Promise<ExecResult>;
     kill: (signal: ExecSignal) => Promise<boolean>;
     detach: () => Promise<string>;
+    stdin: ExecStdin;
   }) {
     this.sessionName = args.sessionName;
+    this.stdin = args.stdin;
     this.#result = args.result;
     this.#kill = args.kill;
     this.#detach = args.detach;
@@ -127,9 +147,13 @@ export interface ExecContext {
 
 interface ExecControl {
   connection?: ExecWsConnection;
+  /** Invoked once the socket is live; lets queued stdin writes proceed. */
+  onConnection?: (connection: ExecWsConnection) => void;
   pendingSignal?: ExecSignal;
   detached: boolean;
 }
+
+const stdinEncoder = new TextEncoder();
 
 /**
  * Runs an exec over the tcp-proxy `/ws/exec` bridge: a non-PTY session with
@@ -167,6 +191,40 @@ export function startExec(
 
   const control: ExecControl = { detached: false };
 
+  // stdin writes can land before the socket exists (token mint + connect are
+  // async); they wait on the live connection rather than being dropped.
+  let rejectConnection!: (reason: unknown) => void;
+  const connectionReady = new Promise<ExecWsConnection>((resolve, reject) => {
+    rejectConnection = reject;
+    control.onConnection = resolve;
+  });
+  // A handle held only for its result must not surface unhandled rejections.
+  connectionReady.catch(() => {});
+
+  const stdin: ExecStdin =
+    options.stdin === true
+      ? {
+          write: async data => {
+            const connection = await connectionReady;
+            connection.writeStdin(
+              typeof data === "string" ? stdinEncoder.encode(data) : data,
+            );
+          },
+          end: async () => {
+            const connection = await connectionReady;
+            connection.closeStdin();
+          },
+        }
+      : {
+          write: () =>
+            Promise.reject(
+              new RailwayError(
+                "stdin was EOF'd at exec start; pass `stdin: true` in ExecOptions to keep it open.",
+              ),
+            ),
+          end: () => Promise.resolve(),
+        };
+
   const kill = async (signal: ExecSignal): Promise<boolean> => {
     if (!control.connection) {
       control.pendingSignal = signal; // delivered once the socket exists
@@ -195,10 +253,11 @@ export function startExec(
     control,
   ).catch(error => {
     rejectSessionName(error);
+    rejectConnection(error);
     throw error;
   });
 
-  return constructHandle({ sessionName, result, kill, detach });
+  return constructHandle({ sessionName, result, kill, detach, stdin });
 }
 
 async function runExec(
@@ -320,6 +379,7 @@ async function runExec(
     },
   });
   control.connection = connection;
+  control.onConnection?.(connection);
 
   // A detach()/kill() that landed during token mint / connect has no socket
   // yet; honor it now that one exists.
@@ -329,8 +389,10 @@ async function runExec(
   }
   if (control.pendingSignal) connection.signal(control.pendingSignal);
 
-  // The SDK provides no stdin; EOF it so commands reading stdin can finish.
-  connection.closeStdin();
+  if (options.stdin !== true) {
+    // No interactive stdin requested; EOF it so commands reading stdin finish.
+    connection.closeStdin();
+  }
 
   if (options.timeoutSec !== undefined) {
     timer = setTimeout(() => {

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -7,7 +7,7 @@ export {
   SandboxTemplateBuildError,
   SandboxTimeoutError,
 } from "./errors.js";
-export { ExecHandle } from "./exec.js";
+export { ExecHandle, type ExecStdin } from "./exec.js";
 export { SandboxFiles } from "./files.js";
 export type { SandboxTemplate } from "./template.js";
 export type {

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -99,6 +99,15 @@ export interface ExecOptions {
    * (`exec({ sessionName })`).
    */
   env?: Record<string, string>;
+  /**
+   * Keep stdin open and expose `ExecHandle.stdin` for interactive writes.
+   * Defaults to `false`: stdin is EOF'd at start so commands that read stdin
+   * can finish. With `true`, write via `handle.stdin.write(...)` and signal
+   * EOF with `handle.stdin.end()` — many commands only exit after EOF.
+   * Works on fresh execs and on reattach (`exec({ sessionName })`), where
+   * writes reach the still-running process.
+   */
+  stdin?: boolean;
   /** Receives each stdout chunk as it arrives. A throw rejects the exec. */
   onStdout?: (chunk: string) => void;
   /** Receives each stderr chunk as it arrives. A throw rejects the exec. */

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -253,6 +253,78 @@ describe("exec", () => {
     ).toThrow(/fresh execs/);
   });
 
+  it("keeps stdin open with stdin: true and frames writes onto the wire", async () => {
+    const { handle, socket } = await execSocket("cat", { stdin: true });
+
+    // Interactive stdin requested — no up-front EOF.
+    expect(socket.sentText.some(f => f.type === "stdin_close")).toBe(false);
+
+    await handle.stdin.write("hello\n");
+    await handle.stdin.write(new TextEncoder().encode("bytes too\n"));
+    expect(socket.sentStdin.map(b => new TextDecoder().decode(b))).toEqual([
+      "hello\n",
+      "bytes too\n",
+    ]);
+
+    await handle.stdin.end();
+    expect(socket.sentText.some(f => f.type === "stdin_close")).toBe(true);
+
+    socket.serverStdout("hello\nbytes too\n");
+    socket.serverExit(0);
+    await expect(handle).resolves.toMatchObject({ exitCode: 0 });
+  });
+
+  it("delivers stdin writes issued before the socket opens", async () => {
+    const { sandbox, ws } = await wsSandbox([shellToken("jwt_abc")]);
+    const handle = sandbox.exec("cat", { stdin: true });
+    // Write immediately — the token mint / connect hasn't finished yet.
+    const write = handle.stdin.write("early\n");
+
+    const socket = await ws.nextSocket();
+    await tick();
+    await write;
+
+    expect(socket.sentStdin.map(b => new TextDecoder().decode(b))).toEqual([
+      "early\n",
+    ]);
+    socket.serverExit(0);
+    await handle;
+  });
+
+  it("rejects stdin.write once the exec has settled", async () => {
+    const { handle, socket } = await execSocket("cat", { stdin: true });
+
+    socket.serverExit(0);
+    await handle;
+
+    await expect(handle.stdin.write("late\n")).rejects.toThrow(/closed/);
+  });
+
+  it("rejects stdin.write when stdin was not requested", async () => {
+    const { handle, socket } = await execSocket("echo hi");
+
+    await expect(handle.stdin.write("nope\n")).rejects.toThrow(/stdin: true/);
+
+    socket.serverExit(0);
+    await handle;
+  });
+
+  it("supports stdin on reattach — writes reach the running session", async () => {
+    const { handle, socket } = await execSocket(
+      { sessionName: "sess_xyz" },
+      { stdin: true },
+    );
+
+    expect(socket.sentText.some(f => f.type === "stdin_close")).toBe(false);
+    await handle.stdin.write("after reattach\n");
+    expect(socket.sentStdin.map(b => new TextDecoder().decode(b))).toEqual([
+      "after reattach\n",
+    ]);
+
+    socket.serverExit(0);
+    await expect(handle).resolves.toMatchObject({ exitCode: 0 });
+  });
+
   it("sends resume_from_last_read when the caller opts in", async () => {
     const { handle, socket } = await execSocket(
       { sessionName: "sess_xyz" },


### PR DESCRIPTION
The `/ws/exec` bridge already supports writing to a running command's stdin — the interactive shell uses it — but the SDK EOFs stdin on every exec. This exposes it: pass `stdin: true` and the handle gets a writer.

```ts
const handle = sandbox.exec("python3 -i", {
  stdin: true,
  onStdout: chunk => process.stdout.write(chunk),
});

await handle.stdin.write("1 + 1\n");
await handle.stdin.end(); // EOF; most commands won't exit without it
const result = await handle;
```

It's for processes you talk to while they run — agent CLIs speaking JSON over stdio, REPLs. A file redirect can't do that: you don't know the second message until you've read the first reply.

Default behavior is unchanged (stdin EOF'd at start) and there are no server changes. Writes before the socket is up wait for the connection; writes after the exec settles reject instead of vanishing into a closed socket; reattach (`exec({ sessionName }, { stdin: true })`) writes to the still-running process. This is a pipe, not a PTY.

Five new unit tests, plus real-sandbox runs: a multi-turn read-loop session, reattach-then-write, and Claude Code taking two stream-json turns down one stdin. Example at `examples/sandboxes/stdin.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)