### PR TITLE
Unwrap nested TypeScript default exports

### DIFF
--- a/src/iac/evaluator.ts
+++ b/src/iac/evaluator.ts
@@ -9,7 +9,7 @@ export async function evaluateRailwayFile(filePath: string, options: GraphCompil
   const mod = await importRailwayFile(absolutePath) as {
     default?: RailwayProgram | ProjectDefinition;
   };
-  const exported = (mod.default ?? mod) as RailwayProgram | ProjectDefinition;
+  const exported = unwrapDefaultExport(mod) as RailwayProgram | ProjectDefinition;
   const definition = await resolveDefinition(exported, options.context);
   const graph = projectDefinitionToGraph(definition);
   const desiredConfig = graphToEnvironmentConfig(graph, options);
@@ -23,6 +23,22 @@ async function importRailwayFile(absolutePath: string): Promise<unknown> {
     return tsImport(url, import.meta.url);
   }
   return import(url);
+}
+
+function unwrapDefaultExport(value: unknown): unknown {
+  let current = value;
+  while (isModuleDefaultWrapper(current)) {
+    current = current.default;
+  }
+  return current;
+}
+
+function isModuleDefaultWrapper(value: unknown): value is { default: unknown } {
+  if (value == null || typeof value !== "object" || !("default" in value)) return false;
+  const candidate = value as Record<string, unknown>;
+  // Project definitions may technically contain arbitrary keys. Only unwrap
+  // module-like objects that do not already look like a Railway project.
+  return candidate.name == null && candidate.resources == null && candidate.services == null && candidate.environments == null;
 }
 
 async function resolveDefinition(exported: RailwayProgram | ProjectDefinition, context: RailwayContextInput = {}): Promise<ProjectDefinition> {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -1,6 +1,9 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, github, graphToEnvironmentConfig, image, postgres, project, service, volume } from "../src/index.js";
+import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, image, postgres, project, service, volume } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { preserve } from "../src/iac/sdk.js";
@@ -15,6 +18,24 @@ describe("Railway IaC", () => {
     expect(diffGraphs({ current, desired }).version).toBe(1);
   });
 
+
+  it("evaluates TypeScript default exports through tsx", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "railway-iac-test-"));
+    const file = join(dir, "railway.ts");
+    await writeFile(file, `
+      export default () => ({
+        name: "app",
+        resources: [{ address: "service.web", type: "service", name: "web" }],
+      });
+    `);
+
+    await expect(evaluateRailwayFile(file)).resolves.toMatchObject({
+      graph: {
+        project: { name: "app" },
+        resources: [{ address: "service.web" }],
+      },
+    });
+  });
 
   it("plans literal variable changes when current value is unknown", () => {
     const current = projectDefinitionToGraph(project("app", {


### PR DESCRIPTION
Fixes IaC evaluation when tsx returns nested default exports, which caused desiredGraph to be empty for railway.ts files.