### PR TITLE
Avoid default region drift for replica counts

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -1,5 +1,5 @@
 import { composePatch, graphToEnvironmentConfig } from "./compiler.js";
-import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, VariableValue, VolumeNode } from "./graph.js";
+import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, ServiceNode, VariableValue, VolumeNode } from "./graph.js";
 import type { EnvironmentConfig } from "./schema.js";
 
 // Wire-contract version for the RailwayChangeSet exchanged with backboard.
@@ -123,6 +123,8 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
     diffTopLevelField({ previous, resource, field: "build", changes });
     if (previous.type === "database" && resource.type === "database") {
       diffDatabaseDeploy({ previous, resource, changes });
+    } else if (previous.type === "service" && resource.type === "service") {
+      diffServiceDeploy({ previous, resource, changes });
     } else {
       diffTopLevelField({ previous, resource, field: "deploy", changes });
     }
@@ -324,6 +326,28 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
   const normalizedAfter = normalizeForDiff(field, after);
   if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
   changes.push(update(resource.address, field, before, after, summaryForField(resource, field, normalizedBefore, normalizedAfter), changedLeafPaths(normalizedBefore, normalizedAfter, field)));
+}
+
+function diffServiceDeploy({ previous, resource, changes }: { previous: ServiceNode; resource: ServiceNode; changes: RailwayChange[] }) {
+  const after = serviceDeployWithCurrentRegion(previous.deploy, resource.deploy);
+  const normalizedBefore = normalizeForDiff("deploy", previous.deploy);
+  const normalizedAfter = normalizeForDiff("deploy", after);
+  if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
+  changes.push(update(resource.address, "deploy", previous.deploy, after, summaryForField(resource, "deploy", normalizedBefore, normalizedAfter), changedLeafPaths(normalizedBefore, normalizedAfter, "deploy")));
+}
+
+function serviceDeployWithCurrentRegion(previous: ServiceNode["deploy"], desired: ServiceNode["deploy"]): ServiceNode["deploy"] {
+  if (desired?.numReplicas == null || desired.multiRegionConfig != null) return desired;
+  const currentRegion = singleDeployRegion(previous);
+  if (currentRegion == null) return desired;
+  const { numReplicas, ...rest } = desired;
+  return { ...rest, multiRegionConfig: { [currentRegion]: { numReplicas } } };
+}
+
+function singleDeployRegion(deploy: ServiceNode["deploy"]): string | undefined {
+  const regions = Object.entries(deploy?.multiRegionConfig ?? {}).filter(([, config]) => config != null);
+  if (regions.length !== 1) return undefined;
+  return regions[0]?.[0];
 }
 
 // A database realizes its mount path and (default) region through Backboard, not repo config:

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -292,24 +292,26 @@ function normalizeBuild(config: ServiceConfigInput): BuildConfig | undefined {
 
 function normalizeDeploy(config: ServiceConfigInput): DeployConfig | undefined {
   const preDeployCommand = config.preDeploy ?? config.preDeployCommand ?? config.run?.preDeploy;
+  const replicaConfig = normalizeReplicas(config.replicas, config.regions);
   return pruneEmpty({
     ...config.deploy,
     startCommand: config.start ?? config.startCommand ?? config.run?.command ?? config.deploy?.startCommand,
     preDeployCommand: Array.isArray(preDeployCommand) ? preDeployCommand : preDeployCommand ? [preDeployCommand] : config.deploy?.preDeployCommand,
     healthcheckPath: config.healthcheck ?? config.healthcheckPath ?? config.run?.healthcheck ?? config.deploy?.healthcheckPath,
     healthcheckTimeout: config.healthcheckTimeout ?? config.run?.healthcheckTimeout ?? config.deploy?.healthcheckTimeout,
-    multiRegionConfig: normalizeReplicas(config.replicas, config.regions) ?? config.deploy?.multiRegionConfig,
+    ...replicaConfig,
+    multiRegionConfig: replicaConfig?.multiRegionConfig ?? config.deploy?.multiRegionConfig,
   }) as DeployConfig | undefined;
 }
 
-function normalizeReplicas(replicas: ServiceConfigInput["replicas"], regions: ServiceConfigInput["regions"]): DeployConfig["multiRegionConfig"] | undefined {
-  if (typeof replicas === "number") return normalizeRegions({ "us-west2": replicas });
-  if (replicas) return normalizeRegions(replicas);
-  if (regions) return normalizeRegions(regions);
+function normalizeReplicas(replicas: ServiceConfigInput["replicas"], regions: ServiceConfigInput["regions"]): Pick<DeployConfig, "numReplicas" | "multiRegionConfig"> | undefined {
+  if (typeof replicas === "number") return { numReplicas: replicas };
+  if (replicas) return { multiRegionConfig: normalizeRegions(replicas) };
+  if (regions) return { multiRegionConfig: normalizeRegions(regions) };
   return undefined;
 }
 
-function normalizeRegions(regions: Record<string, RegionConfig>): DeployConfig["multiRegionConfig"] {
+function normalizeRegions(regions: Record<string, RegionConfig>): NonNullable<DeployConfig["multiRegionConfig"]> {
   return Object.fromEntries(
     Object.entries(regions).map(([region, value]) => [
       region,
@@ -317,7 +319,7 @@ function normalizeRegions(regions: Record<string, RegionConfig>): DeployConfig["
         ? { numReplicas: value }
         : (pruneEmpty({ numReplicas: value.count ?? value.replicas, stackerAssignment: value.stacker }) ?? {}),
     ]),
-  ) as DeployConfig["multiRegionConfig"];
+  ) as NonNullable<DeployConfig["multiRegionConfig"]>;
 }
 
 function normalizeNetworking(config: ServiceConfigInput): ServiceNetworking | undefined {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, image, postgres, project, service, volume } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
-import { RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
+import { changeSetToEnvironmentPatch, RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { preserve } from "../src/iac/sdk.js";
 
 describe("Railway IaC", () => {
@@ -34,6 +34,41 @@ describe("Railway IaC", () => {
         project: { name: "app" },
         resources: [{ address: "service.web" }],
       },
+    });
+  });
+
+  it("treats numeric replicas as count-only without defaulting to us-west2", () => {
+    const graph = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { replicas: 1 })],
+    }));
+
+    expect(graph.resources).toContainEqual(expect.objectContaining({
+      address: "service.web",
+      deploy: { numReplicas: 1 },
+    }));
+    expect(graphToEnvironmentConfig(graph).services?.web?.deploy).toEqual({
+      numReplicas: 1,
+    });
+  });
+
+  it("does not include a region change when applying count-only replica changes", () => {
+    const current = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { deploy: { multiRegionConfig: { "us-east4": { numReplicas: 1 } } } })],
+    }));
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { replicas: 2 })],
+    }));
+    const changeSet = diffGraphs({ current, desired });
+
+    expect(changeSet.changes).toMatchObject([
+      { kind: "resource.update", address: "service.web", field: "deploy" },
+    ]);
+    expect(changeSetToEnvironmentPatch({
+      currentGraph: current,
+      currentConfig: graphToEnvironmentConfig(current),
+      changeSet,
+    }).services?.web?.deploy).toEqual({
+      multiRegionConfig: { "us-east4": { numReplicas: 2 } },
     });
   });
 


### PR DESCRIPTION
Makes numeric replicas count-only instead of defaulting to us-west2, and preserves the current single deploy region when applying count-only replica updates.