### PR TITLE
Treat registry credentials as write-only in change-set diffs

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -414,15 +414,32 @@ function isMaskedRegistryCredentials(value: unknown): boolean {
 function stripWriteOnlyRegistryCredentials(before: unknown, after: unknown): [unknown, unknown] {
   const beforeCredentials = (before as { registryCredentials?: unknown } | undefined)?.registryCredentials;
   const afterCredentials = (after as { registryCredentials?: unknown } | undefined)?.registryCredentials;
-  const desiredManagesCredentials = afterCredentials != null && !isMaskedRegistryCredentials(afterCredentials);
-  const stripBoth = !desiredManagesCredentials || isMaskedRegistryCredentials(beforeCredentials);
-  const strip = (value: unknown, credentials: unknown) => {
-    if (credentials === undefined || value == null || typeof value !== "object") return value;
+  // Sentinel-valued fields in the desired config are echoes of a masked read: drop the
+  // field but keep any real sibling field so a partial credential update still plans.
+  const desiredCredentials = realCredentialFields(afterCredentials);
+  const withCredentials = (value: unknown, credentials: Record<string, unknown> | undefined) => {
+    if (value == null || typeof value !== "object") return value;
     const copy = { ...(value as Record<string, unknown>) };
-    delete copy.registryCredentials;
+    if (credentials === undefined) delete copy.registryCredentials;
+    else copy.registryCredentials = credentials;
     return Object.keys(copy).length === 0 ? undefined : copy;
   };
-  return stripBoth ? [strip(before, beforeCredentials), strip(after, afterCredentials)] : [before, after];
+  const desiredSide = afterCredentials === undefined ? after : withCredentials(after, desiredCredentials);
+  if (desiredCredentials !== undefined && !isMaskedRegistryCredentials(beforeCredentials)) {
+    return [before, desiredSide];
+  }
+  const strippedBefore = beforeCredentials === undefined ? before : withCredentials(before, undefined);
+  const strippedAfter = desiredCredentials === undefined ? desiredSide : withCredentials(desiredSide, undefined);
+  return [strippedBefore, strippedAfter];
+}
+
+// Remove sentinel-valued fields; undefined when nothing real remains.
+function realCredentialFields(credentials: unknown): Record<string, unknown> | undefined {
+  if (credentials == null || typeof credentials !== "object") return undefined;
+  const entries = Object.entries(credentials as Record<string, unknown>).filter(
+    ([, value]) => value != null && value !== MASKED_CREDENTIAL_VALUE,
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 // Backboard owns requiredMountPath; it is represented in the graph by node.defaultMountPath and

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -330,11 +330,14 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
 }
 
 function diffServiceDeploy({ previous, resource, changes }: { previous: ServiceNode; resource: ServiceNode; changes: RailwayChange[] }) {
-  const after = serviceDeployWithCurrentRegion(previous.deploy, resource.deploy);
-  const normalizedBefore = normalizeForDiff("deploy", previous.deploy);
+  const [before, after] = stripWriteOnlyRegistryCredentials(
+    previous.deploy,
+    serviceDeployWithCurrentRegion(previous.deploy, resource.deploy),
+  );
+  const normalizedBefore = normalizeForDiff("deploy", before);
   const normalizedAfter = normalizeForDiff("deploy", after);
   if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
-  changes.push(update(resource.address, "deploy", previous.deploy, after, summaryForField(resource, "deploy", normalizedBefore, normalizedAfter), changedLeafPaths(normalizedBefore, normalizedAfter, "deploy")));
+  changes.push(update(resource.address, "deploy", before, after, summaryForField(resource, "deploy", normalizedBefore, normalizedAfter), changedLeafPaths(normalizedBefore, normalizedAfter, "deploy")));
 }
 
 function serviceDeployWithCurrentRegion(previous: ServiceNode["deploy"], desired: ServiceNode["deploy"]): ServiceNode["deploy"] {

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -317,9 +317,10 @@ function diffVolumeAttachments({ previous, resource, changes }: { previous: Reso
 }
 
 function diffTopLevelField({ previous, resource, field, changes }: { previous: ResourceNode; resource: ResourceNode; field: string; changes: RailwayChange[] }) {
-  const before = (previous as unknown as Record<string, unknown>)[field];
-  const after = (resource as unknown as Record<string, unknown>)[field];
+  let before = (previous as unknown as Record<string, unknown>)[field];
+  let after = (resource as unknown as Record<string, unknown>)[field];
   if (field === "source" && previous.type === "database" && isEquivalentDatabaseSource(previous, after)) return;
+  if (field === "deploy") [before, after] = stripWriteOnlyRegistryCredentials(before, after);
   const normalizedBefore = normalizeForDiff(field, before);
   const normalizedAfter = normalizeForDiff(field, after);
   if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
@@ -345,24 +346,56 @@ function diffVolumeConfig({ previous, resource, changes }: { previous: VolumeNod
 }
 
 function diffDatabaseDeploy({ previous, resource, changes }: { previous: DatabaseNode; resource: DatabaseNode; changes: RailwayChange[] }) {
+  const [previousDeploy, resourceDeploy] = stripWriteOnlyRegistryCredentials(previous.deploy, resource.deploy);
   const previousRegion = databaseRegion(previous);
   const desiredRegion = databaseRegion(resource);
   if (desiredRegion !== undefined && desiredRegion !== previousRegion) {
     changes.push(update(
       resource.address,
       "deploy",
-      previous.deploy,
-      resource.deploy,
+      previousDeploy,
+      resourceDeploy,
       `Move database ${resource.name} to ${desiredRegion}`,
-      changedLeafPaths(normalizeDatabaseDeploy(previous.deploy), normalizeDatabaseDeploy(resource.deploy), "deploy"),
+      changedLeafPaths(normalizeDatabaseDeploy(previousDeploy), normalizeDatabaseDeploy(resourceDeploy), "deploy"),
       "destructive",
     ));
     return;
   }
-  const before = normalizeDatabaseDeploy(previous.deploy);
-  const after = normalizeDatabaseDeploy(resource.deploy);
+  const before = normalizeDatabaseDeploy(previousDeploy);
+  const after = normalizeDatabaseDeploy(resourceDeploy);
   if (stableStringify(before) === stableStringify(after)) return;
-  changes.push(update(resource.address, "deploy", previous.deploy, resource.deploy, summaryForField(resource, "deploy", before, after), changedLeafPaths(before, after, "deploy")));
+  changes.push(update(resource.address, "deploy", previousDeploy, resourceDeploy, summaryForField(resource, "deploy", before, after), changedLeafPaths(before, after, "deploy")));
+}
+
+// Registry credentials are write-only: Backboard masks them in config reads unless
+// variables are decrypted — a sentinel value ("*****") in Environment.config, or null in
+// staged-patch reads. A masked value proves credentials exist but not what they are, so:
+//   - remote masked + desired set   → assume applied; no drift (rotate with --decrypt-variables)
+//   - remote set    + desired unset → no removal churn (Backboard exempts credentials from nulling)
+//   - remote absent + desired set   → first apply still plans an update
+// Stripped values are also excluded from the emitted change payload, so a masked or
+// sentinel credential can never round-trip into a change set.
+const MASKED_CREDENTIAL_VALUE = "*****";
+
+function isMaskedRegistryCredentials(value: unknown): boolean {
+  if (value === null) return true;
+  if (value == null || typeof value !== "object") return false;
+  const credentials = value as { username?: unknown; password?: unknown };
+  return credentials.username === MASKED_CREDENTIAL_VALUE || credentials.password === MASKED_CREDENTIAL_VALUE;
+}
+
+function stripWriteOnlyRegistryCredentials(before: unknown, after: unknown): [unknown, unknown] {
+  const beforeCredentials = (before as { registryCredentials?: unknown } | undefined)?.registryCredentials;
+  const afterCredentials = (after as { registryCredentials?: unknown } | undefined)?.registryCredentials;
+  const desiredManagesCredentials = afterCredentials != null && !isMaskedRegistryCredentials(afterCredentials);
+  const stripBoth = !desiredManagesCredentials || isMaskedRegistryCredentials(beforeCredentials);
+  const strip = (value: unknown, credentials: unknown) => {
+    if (credentials === undefined || value == null || typeof value !== "object") return value;
+    const copy = { ...(value as Record<string, unknown>) };
+    delete copy.registryCredentials;
+    return Object.keys(copy).length === 0 ? undefined : copy;
+  };
+  return stripBoth ? [strip(before, beforeCredentials), strip(after, afterCredentials)] : [before, after];
 }
 
 // Backboard owns requiredMountPath; it is represented in the graph by node.defaultMountPath and
@@ -408,6 +441,10 @@ function changedLeafPaths(before: unknown, after: unknown, prefix: string): stri
     .filter(key => key === "" || !changed.some(other => other !== key && other.startsWith(`${key}.`)))
     .map(key => {
       const path = key ? `${prefix}.${key}` : prefix;
+      // Credential values must never appear in plan output (terminals, CI logs)
+      if (path.includes("registryCredentials")) {
+        return `${friendlyPath(path)} (${REDACTED_VARIABLE_VALUE} → ${REDACTED_VARIABLE_VALUE})`;
+      }
       const beforeValue = beforeFlat[key];
       const afterValue = afterFlat[key];
       return `${friendlyPath(path)} (${formatDiffValue(beforeValue)} → ${formatDiffValue(afterValue)})`;

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -251,6 +251,110 @@ describe("Railway IaC", () => {
     expect(change?.details?.[0]).not.toContain("«hidden»");
   });
 
+  describe("write-only registry credentials", () => {
+    const PASSWORD = "hunter2-secret";
+    const desiredWithCredentials = () => projectDefinitionToGraph(project("app", {
+      resources: [service("web", {
+        source: image("ghcr.io/acme/api:1.2.3"),
+        deploy: { registryCredentials: { username: "robot", password: PASSWORD } },
+      })],
+    }));
+
+    it("plans the first apply when the environment has no credentials", () => {
+      const current = environmentConfigToGraph({
+        services: { web: { source: { image: "ghcr.io/acme/api:1.2.3" } } },
+      }, { projectName: "app" });
+
+      const changes = diffGraphs({ current, desired: desiredWithCredentials() }).changes;
+      expect(changes).toMatchObject([
+        { kind: "resource.update", address: "service.web", field: "deploy" },
+      ]);
+      // Plan output (details) must not leak the password even on first apply.
+      const change = changes[0] as { details?: string[] };
+      expect(JSON.stringify(change.details ?? [])).not.toContain(PASSWORD);
+    });
+
+    it("does not churn when the environment masks credentials with the sentinel", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "*****", password: "*****" } },
+        } },
+      }, { projectName: "app" });
+
+      expect(diffGraphs({ current, desired: desiredWithCredentials() }).changes).toEqual([]);
+    });
+
+    it("does not churn when a staged-patch read nulls credentials", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: null },
+        } },
+      }, { projectName: "app" });
+
+      expect(diffGraphs({ current, desired: desiredWithCredentials() }).changes).toEqual([]);
+    });
+
+    it("never plans credential removal when the desired config omits them", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "*****", password: "*****" } },
+        } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web", { source: image("ghcr.io/acme/api:1.2.3") })],
+      }));
+
+      expect(diffGraphs({ current, desired }).changes).toEqual([]);
+    });
+
+    it("plans a rotation when the remote config was fetched decrypted", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "robot", password: "old-password" } },
+        } },
+      }, { projectName: "app" });
+
+      const changes = diffGraphs({ current, desired: desiredWithCredentials() }).changes;
+      expect(changes).toMatchObject([
+        { kind: "resource.update", address: "service.web", field: "deploy" },
+      ]);
+      const change = changes[0] as { summary?: string; details?: string[] };
+      const rendered = JSON.stringify([change.summary, change.details]);
+      expect(rendered).toContain("registryCredentials");
+      expect(rendered).not.toContain(PASSWORD);
+      expect(rendered).not.toContain("old-password");
+    });
+
+    it("excludes masked credentials from the change payload of unrelated deploy edits", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: {
+            startCommand: "old-start",
+            registryCredentials: { username: "*****", password: "*****" },
+          },
+        } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web", {
+          source: image("ghcr.io/acme/api:1.2.3"),
+          deploy: { startCommand: "new-start", registryCredentials: { username: "robot", password: PASSWORD } },
+        })],
+      }));
+
+      const changes = diffGraphs({ current, desired }).changes;
+      expect(changes).toMatchObject([
+        { kind: "resource.update", address: "service.web", field: "deploy" },
+      ]);
+      const change = changes[0] as { before?: unknown; after?: unknown };
+      expect(JSON.stringify([change.before, change.after])).not.toContain("registryCredentials");
+    });
+  });
+
   it("refuses to manage a service still owned by railway.json/toml", () => {
     const current = environmentConfigToGraph({
       services: { web: { source: { repo: "r" }, configFile: "railway.json" } },

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -364,6 +364,25 @@ describe("Railway IaC", () => {
       expect(rendered).not.toContain("old-password");
     });
 
+    it("keeps the real field when the desired config echoes one sentinel", () => {
+      const current = environmentConfigToGraph({
+        services: { web: { source: { image: "ghcr.io/acme/api:1.2.3" } } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web", {
+          source: image("ghcr.io/acme/api:1.2.3"),
+          deploy: { registryCredentials: { username: "*****", password: PASSWORD } },
+        })],
+      }));
+
+      const changes = diffGraphs({ current, desired }).changes;
+      expect(changes).toMatchObject([
+        { kind: "resource.update", address: "service.web", field: "deploy" },
+      ]);
+      const change = changes[0] as { after?: unknown };
+      expect(change.after).toEqual({ registryCredentials: { password: PASSWORD } });
+    });
+
     it("excludes masked credentials from the change payload of unrelated deploy edits", () => {
       const current = environmentConfigToGraph({
         services: { web: {


### PR DESCRIPTION
Companion to railwayapp/mono#32674, which stops `environment.config(decryptVariables: false)` from returning plaintext registry credentials and instead returns a masked sentinel (`{username: "*****", password: "*****"}`; staged-patch reads return `null`).

Without this change, an IaC config declaring `deploy.registryCredentials` would diff against the masked remote value and plan a credential update — with a redeploy — on every single plan/apply.

## Behavior

| Remote (current) | Desired | Plan |
|---|---|---|
| absent | credentials set | update (first apply) |
| masked sentinel / null | credentials set | no change — assumed applied |
| masked sentinel | absent | no change — removal is never planned (Backboard exempts credentials from nulling) |
| plaintext (`--decrypt-variables`) | different credentials | update (rotation) |

Masked/sentinel values are stripped from emitted change payloads so `*****` can never round-trip into a change set (Backboard's `encryptPatch` also guards against this server-side), and credential values are redacted from plan output details, matching the existing variable-redaction rule for terminals and CI logs.

Rotation with a masked remote is intentionally not detectable — plan with `--decrypt-variables` (MEMBER scope) to rotate credentials.

## Merge order

Safe to merge before or after mono#32674: the diff rules handle both the old plaintext echo and the new sentinel. But mono#32674 should not ship long before this one, or credential-declaring IaC users get perpetual plan drift in the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)