### PR TITLE
Stamp runner responses with the SDK version

### DIFF
--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -2,7 +2,7 @@
 // unbundled (vitest/tsx).
 declare const __RAILWAY_SDK_VERSION__: string | undefined;
 
-const SDK_VERSION =
+export const SDK_VERSION =
   typeof __RAILWAY_SDK_VERSION__ !== "undefined"
     ? __RAILWAY_SDK_VERSION__
     : "0.0.0-dev";

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -6,6 +6,7 @@ import { evaluateRailwayProject, findRailwayFile } from "./project.js";
 import { renderRailwayGraphTypes } from "./typegen.js";
 import type { EnvironmentConfig } from "./schema.js";
 import type { RailwayAuthType } from "../core/config.js";
+import { SDK_VERSION } from "../core/version.js";
 import type { RailwayContextInput } from "./sdk.js";
 
 export interface RailwayIacRunnerRequest {
@@ -92,7 +93,10 @@ export interface RailwayIacApplyResponse extends Omit<RailwayIacStageResponse, "
   stagedPatchId?: string;
 }
 
-export type RailwayIacRunnerResponse = RailwayIacEvaluateResponse | RailwayIacTypegenResponse | RailwayIacCurrentResponse | RailwayIacPlanResponse | RailwayIacStageResponse | RailwayIacApplyResponse;
+export type RailwayIacRunnerResponse = (RailwayIacEvaluateResponse | RailwayIacTypegenResponse | RailwayIacCurrentResponse | RailwayIacPlanResponse | RailwayIacStageResponse | RailwayIacApplyResponse) & {
+  /** SDK version that produced this response; consumers use it to detect outdated runners. */
+  sdkVersion?: string;
+};
 
 type RunnerCommand = NonNullable<RailwayIacRunnerRequest["command"]>;
 
@@ -116,9 +120,9 @@ export async function runRailwayIac(request: RailwayIacRunnerRequest = {}): Prom
       graph: evaluated.graph,
       diagnostics: graphDiagnostics(evaluated.graph),
     };
-    return await runEvaluatedCommand(command, input);
+    return { sdkVersion: SDK_VERSION, ...(await runEvaluatedCommand(command, input)) };
   } catch (error) {
-    return errorResponse(command, file, error);
+    return { sdkVersion: SDK_VERSION, ...errorResponse(command, file, error) };
   }
 }
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, image, postgres, project, service, volume } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { changeSetToEnvironmentPatch, RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
+import { runRailwayIac } from "../src/iac/runner.js";
 import { preserve } from "../src/iac/sdk.js";
 
 describe("Railway IaC", () => {
@@ -70,6 +71,17 @@ describe("Railway IaC", () => {
     }).services?.web?.deploy).toEqual({
       multiRegionConfig: { "us-east4": { numReplicas: 2 } },
     });
+  });
+
+  it("stamps runner responses with the SDK version", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "railway-iac-version-"));
+    const file = join(dir, "railway.ts");
+    await writeFile(file, `export default () => ({ name: "app", resources: [] });`);
+
+    const response = await runRailwayIac({ command: "evaluate", file });
+
+    // Unbundled runs fall back to the dev version; the tsup build injects the real one.
+    expect(response.sdkVersion).toBe("0.0.0-dev");
   });
 
   it("plans literal variable changes when current value is unknown", () => {


### PR DESCRIPTION
First half of the fix for the enterprise report "volumes listed in resources but no generated volume(...) declaration" on CLI v5.23.3.

Investigation ruled out the CLI renderer (regression-tested against name collisions, database volumes, orphan volumes), the SDK graph pipeline (volumes emitted since v3.4.0), and backboard serialization (all live volume instances land in config.volumes). The remaining mechanism is **runner version skew**: `railway config pull` executes the project-installed `railway` package, and pre-3.4.0 versions emit volume-less graphs with nothing flagging the omission — the CLI can't distinguish "no volumes" from "runner too old to know about volumes".

This adds `sdkVersion` to every runner response (evaluate/typegen/current/plan/stage/apply, including error responses), sourced from the existing tsup-injected version constant. Companion CLI PR warns on pull when the field is absent.

Verified: bundled `dist/iac/bin.js` emits `"sdkVersion":"3.5.2"`; unbundled runs fall back to `0.0.0-dev` (tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)