### PR TITLE
Never plan implicit volume deletion

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -150,6 +150,24 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
 
   for (const resource of current.resources) {
     if (desiredByAddress.has(resource.address)) continue;
+    // Volumes hold data, and database volumes are realized by Backboard without ever
+    // appearing in authored config — a plan against a postgres() database would otherwise
+    // delete its volume on every apply. Never plan an implicit volume deletion; deleting
+    // data stays a dashboard operation. Warn when a still-mounted volume vanished from
+    // the config so the omission is visible.
+    if (resource.type === "volume") {
+      const mountedByPersistingService = current.edges.some(
+        edge => edge.type === "mount" && edge.to === resource.address && desiredByAddress.has(edge.from),
+      );
+      if (mountedByPersistingService) {
+        diagnostics.push({
+          severity: "warning",
+          path: `resources.${resource.address}`,
+          message: `Volume ${resource.name} exists on Railway but is not declared in the config. Volumes are never deleted by config apply; delete it from the dashboard if that is intended.`,
+        });
+      }
+      continue;
+    }
     changes.push({
       kind: "resource.delete",
       address: resource.address,

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -227,6 +227,58 @@ describe("Railway IaC", () => {
     expect(diffGraphs({ current, desired }).changes).toEqual([]);
   });
 
+  it("never plans deletion of a database-realized volume", () => {
+    // postgres() authors no volume declaration, but the platform realizes one.
+    // Re-planning must not schedule the data volume for deletion.
+    const current = environmentConfigToGraph({
+      services: {
+        db: {
+          source: { image: "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+          deploy: { requiredMountPath: "/var/lib/postgresql/data" },
+          volumeMounts: { "vol-1": { mountPath: "/var/lib/postgresql/data" } },
+        },
+      },
+      volumes: { "vol-1": { sizeMB: 50000, region: "us-west2" } },
+    }, {
+      projectName: "app",
+      serviceNamesById: { db: "db" },
+      volumeNamesById: { "vol-1": "postgres-volume" },
+    });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [postgres("db")],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({ current, desired });
+    expect(changes.filter(change => change.kind === "resource.delete")).toEqual([]);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("warns instead of deleting when a mounted volume vanishes from config", () => {
+    const current = environmentConfigToGraph({
+      services: {
+        web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          volumeMounts: { "vol-1": { mountPath: "/data" } },
+        },
+      },
+      volumes: { "vol-1": { sizeMB: 1024, region: "us-west2" } },
+    }, {
+      projectName: "app",
+      serviceNamesById: { web: "web" },
+      volumeNamesById: { "vol-1": "data" },
+    });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: image("ghcr.io/acme/api:1.2.3") })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({ current, desired });
+    expect(changes.filter(change => change.kind === "resource.delete")).toEqual([]);
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      message: expect.stringContaining("never deleted"),
+    }));
+  });
+
   it("marks removing a service as a destructive delete", () => {
     const current = environmentConfigToGraph({
       services: { web: { source: { repo: "railwayapp/demo" } }, api: { source: { repo: "railwayapp/api" } } },


### PR DESCRIPTION
Found by the IaC e2e harness (railwayapp/iac-test-harness) running against a throwaway project: applying a config authored with `postgres()` / `redis()` / `mysql()` plans — and with `--confirm-destructive`, executes — **deletion of the database data volumes** on every re-apply.

Mechanism: the platform realizes database volumes outside authored config, so the current graph contains `volume.postgres-volume` etc. while the desired graph (authored helpers) declares no volume resources. The delete loop in `diffGraphs` planned `resource.delete` for any current-not-in-desired resource, volumes included.

Fix: volumes are never implicitly deleted. Dropping a volume from config no longer plans its destruction — deleting data stays a dashboard operation, matching the existing v0 stance that volume lifecycle is not authoring-managed ("never plan an accidental unmount…"). When a still-**mounted** volume vanishes from the config, plan emits a warning diagnostic so the omission is visible; database-realized volumes (no mount edge in the graph) stay silent so authored-database plans are clean.

No existing behavior depended on implicit volume deletes (no test covered it). Explicit volume updates (resize/region) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)