### PR TITLE
Pin npm to 11.x for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         run: mise run package-check
 
       - name: Use npm with Trusted Publisher support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Publish to npm
         run: npm publish --access public


### PR DESCRIPTION
npm@latest resolves to 12.x now, and npm 12's publish provenance path crashes with `Cannot find module 'sigstore'` (npm/cli#9722, unresolved). Pin the trusted-publisher step to `npm@11` — 11.5+ has Trusted Publisher support, so nothing is lost. Unpin when the upstream issue closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)