### PR TITLE
Fix IaC credential and state transitions

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -349,8 +349,8 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
 
 function diffServiceDeploy({ previous, resource, changes }: { previous: ServiceNode; resource: ServiceNode; changes: RailwayChange[] }) {
   const desiredDeploy = serviceDeployWithCurrentRegion(previous.deploy, resource.deploy);
-  const switchingFromImageToGitHub = previous.source?.type === "image" && resource.source?.type === "github";
-  const [before, after] = switchingFromImageToGitHub && previous.deploy?.registryCredentials !== undefined
+  const switchingAwayFromImage = previous.source?.type === "image" && resource.source?.type !== "image";
+  const [before, after] = switchingAwayFromImage && previous.deploy?.registryCredentials !== undefined
     ? [withoutRegistryCredentials(previous.deploy), { ...(desiredDeploy ?? {}), registryCredentials: null }]
     : stripWriteOnlyRegistryCredentials(previous.deploy, desiredDeploy);
   const normalizedBefore = normalizeForDiff("deploy", before);

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -348,10 +348,11 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
 }
 
 function diffServiceDeploy({ previous, resource, changes }: { previous: ServiceNode; resource: ServiceNode; changes: RailwayChange[] }) {
-  const [before, after] = stripWriteOnlyRegistryCredentials(
-    previous.deploy,
-    serviceDeployWithCurrentRegion(previous.deploy, resource.deploy),
-  );
+  const desiredDeploy = serviceDeployWithCurrentRegion(previous.deploy, resource.deploy);
+  const switchingFromImageToGitHub = previous.source?.type === "image" && resource.source?.type === "github";
+  const [before, after] = switchingFromImageToGitHub && previous.deploy?.registryCredentials !== undefined
+    ? [withoutRegistryCredentials(previous.deploy), { ...(desiredDeploy ?? {}), registryCredentials: null }]
+    : stripWriteOnlyRegistryCredentials(previous.deploy, desiredDeploy);
   const normalizedBefore = normalizeForDiff("deploy", before);
   const normalizedAfter = normalizeForDiff("deploy", after);
   if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
@@ -468,12 +469,25 @@ function stripWriteOnlyRegistryCredentials(before: unknown, after: unknown): [un
     return Object.keys(copy).length === 0 ? undefined : copy;
   };
   const desiredSide = afterCredentials === undefined ? after : withCredentials(after, desiredCredentials);
+  // A mixed sentinel/real object can only come from editing a pulled config.
+  // Keep the real fields even though the remote side is masked; otherwise a
+  // partial rotation is silently treated as already applied.
+  if (desiredCredentials !== undefined && isMaskedRegistryCredentials(afterCredentials)) {
+    return [withCredentials(before, undefined), desiredSide];
+  }
   if (desiredCredentials !== undefined && !isMaskedRegistryCredentials(beforeCredentials)) {
     return [before, desiredSide];
   }
   const strippedBefore = beforeCredentials === undefined ? before : withCredentials(before, undefined);
   const strippedAfter = desiredCredentials === undefined ? desiredSide : withCredentials(desiredSide, undefined);
   return [strippedBefore, strippedAfter];
+}
+
+function withoutRegistryCredentials(deploy: unknown): unknown {
+  if (deploy == null || typeof deploy !== "object") return deploy;
+  const copy = { ...(deploy as Record<string, unknown>) };
+  delete copy.registryCredentials;
+  return Object.keys(copy).length === 0 ? undefined : copy;
 }
 
 // Remove sentinel-valued fields; undefined when nothing real remains.

--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -19,6 +19,7 @@ export interface CurrentEnvironmentResult {
   serviceNamesById: Record<string, string>;
   volumeNamesById: Record<string, string>;
   bucketNamesById: Record<string, string>;
+  bucketGroupIdsById: Record<string, string>;
   customDomainsByServiceId: Record<string, Record<string, { port?: number }>>;
 }
 
@@ -54,7 +55,7 @@ export interface ChangeSetApplyResult {
 
 export interface ProjectService { id: string; name: string }
 export interface ProjectVolume { id: string; name?: string | null; serviceId?: string | null }
-export interface ProjectBucket { id: string; name: string }
+export interface ProjectBucket { id: string; name: string; groupId?: string | null }
 
 export interface EnsuredGraphResources {
   serviceIdsByName: Record<string, string>;
@@ -90,6 +91,7 @@ export class IacClient {
       serviceNamesById: Object.fromEntries(services.map(service => [service.id, service.name])),
       volumeNamesById: Object.fromEntries(volumes.flatMap(volume => volume.name ? [[volume.id, volume.name] as const] : [])),
       bucketNamesById: Object.fromEntries(buckets.map(bucket => [bucket.id, bucket.name])),
+      bucketGroupIdsById: Object.fromEntries(buckets.flatMap(bucket => bucket.groupId ? [[bucket.id, bucket.groupId] as const] : [])),
       customDomainsByServiceId,
       ...(data.environment.configEtag ? { configEtag: data.environment.configEtag } : {}),
     };
@@ -125,7 +127,7 @@ export class IacClient {
 
   async getProjectBuckets(projectId: string): Promise<ProjectBucket[]> {
     const data = await gql<{ project: { buckets: { edges: Array<{ node: ProjectBucket }> } } }, { projectId: string }>(this.#config, `query IacProjectBuckets($projectId: String!) {
-      project(id: $projectId) { buckets(first: 1000) { edges { node { id name } } } }
+      project(id: $projectId) { buckets(first: 1000) { edges { node { id name groupId } } } }
     }`, { projectId });
     return data.project.buckets.edges.map(edge => edge.node);
   }
@@ -134,7 +136,7 @@ export class IacClient {
     const entries = await Promise.all(services.map(async service => {
       const data = await gql<{ domains: { customDomains: Array<{ domain: string; targetPort?: number | null }> } }, { projectId: string; environmentId: string; serviceId: string }>(this.#config, `query IacServiceDomains($projectId: String!, $environmentId: String!, $serviceId: String!) {
         domains(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId) { customDomains { domain targetPort } }
-      }`, { projectId, environmentId, serviceId: service.id }).catch(() => ({ domains: { customDomains: [] } }));
+      }`, { projectId, environmentId, serviceId: service.id });
       return [service.id, Object.fromEntries(data.domains.customDomains.map(domain => [domain.domain, domain.targetPort == null ? {} : { port: domain.targetPort }]))] as const;
     }));
     return Object.fromEntries(entries.filter(([, domains]) => Object.keys(domains).length > 0));

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -133,7 +133,7 @@ export function graphToEnvironmentConfig(graph: RailwayGraph, options: GraphComp
 
 export function environmentConfigToGraph(
   config: EnvironmentConfig,
-  options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
+  options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; bucketGroupIdsById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
 ): RailwayGraph {
   const resources: ResourceNode[] = [];
   const groupNamesById = Object.fromEntries(
@@ -207,7 +207,7 @@ export function environmentConfigToGraph(
   for (const [bucketId, bucketConfig] of Object.entries(config.buckets ?? {})) {
     if (bucketConfig == null || bucketConfig.isDeleted) continue;
     const name = options.bucketNamesById?.[bucketId] ?? bucketId;
-    const groupId = (bucketConfig as { groupId?: string | null }).groupId;
+    const groupId = options.bucketGroupIdsById?.[bucketId] ?? (bucketConfig as { groupId?: string | null }).groupId;
     resources.push({
       address: resourceAddress("bucket", name) as `bucket.${string}`,
       type: "bucket",

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -266,6 +266,7 @@ function graphFromCurrentEnvironment(current: CurrentEnvironmentResult, desiredG
     serviceNamesById: current.serviceNamesById,
     volumeNamesById: current.volumeNamesById,
     bucketNamesById: current.bucketNamesById,
+    bucketGroupIdsById: current.bucketGroupIdsById,
     customDomainsByServiceId: current.customDomainsByServiceId,
   });
 }

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -512,6 +512,31 @@ describe("Railway IaC", () => {
       expect(rendered).not.toContain("old-password");
     });
 
+    it("rotates one field when both remote credentials are masked", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "*****", password: "*****" } },
+        } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web", {
+          source: image("ghcr.io/acme/api:1.2.3"),
+          deploy: { registryCredentials: { username: "*****", password: PASSWORD } },
+        })],
+      }));
+
+      const changes = diffGraphs({ current, desired }).changes;
+      expect(changes).toMatchObject([
+        {
+          kind: "resource.update",
+          address: "service.web",
+          field: "deploy",
+          after: { registryCredentials: { password: PASSWORD } },
+        },
+      ]);
+    });
+
     it("keeps the real field when the desired config echoes one sentinel", () => {
       const current = environmentConfigToGraph({
         services: { web: { source: { image: "ghcr.io/acme/api:1.2.3" } } },
@@ -529,6 +554,28 @@ describe("Railway IaC", () => {
       ]);
       const change = changes[0] as { after?: unknown };
       expect(change.after).toEqual({ registryCredentials: { password: PASSWORD } });
+    });
+
+    it("explicitly clears credentials when switching from image to GitHub", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "*****", password: "*****" } },
+        } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web", { source: github("railwayapp/api") })],
+      }));
+
+      expect(diffGraphs({ current, desired }).changes).toMatchObject([
+        { kind: "resource.update", address: "service.web", field: "source" },
+        {
+          kind: "resource.update",
+          address: "service.web",
+          field: "deploy",
+          after: { registryCredentials: null },
+        },
+      ]);
     });
 
     it("excludes masked credentials from the change payload of unrelated deploy edits", () => {
@@ -568,6 +615,25 @@ describe("Railway IaC", () => {
     const { changes, diagnostics } = diffGraphs({ current, desired });
     expect(diagnostics).toContainEqual(expect.objectContaining({ severity: "error", message: expect.stringContaining("railway.json") }));
     expect(changes).toEqual([]);
+  });
+
+  it("restores bucket group membership from project canvas state", () => {
+    const graph = environmentConfigToGraph(
+      {
+        groups: { "group-id": { name: "Storage" } },
+        buckets: { "bucket-id": { region: "iad" } },
+      },
+      {
+        projectName: "app",
+        bucketNamesById: { "bucket-id": "uploads" },
+        bucketGroupIdsById: { "bucket-id": "group-id" },
+      },
+    );
+
+    expect(graph.resources).toContainEqual(expect.objectContaining({
+      address: "bucket.uploads",
+      groupId: "Storage",
+    }));
   });
 
   it("flags a bucket region change as an immutable-region error", () => {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -578,6 +578,27 @@ describe("Railway IaC", () => {
       ]);
     });
 
+    it("clears credentials when an image source is removed", () => {
+      const current = environmentConfigToGraph({
+        services: { web: {
+          source: { image: "ghcr.io/acme/api:1.2.3" },
+          deploy: { registryCredentials: { username: "*****", password: "*****" } },
+        } },
+      }, { projectName: "app" });
+      const desired = projectDefinitionToGraph(project("app", {
+        resources: [service("web")],
+      }));
+
+      expect(diffGraphs({ current, desired }).changes).toContainEqual(
+        expect.objectContaining({
+          kind: "resource.update",
+          address: "service.web",
+          field: "deploy",
+          after: { registryCredentials: null },
+        }),
+      );
+    });
+
     it("excludes masked credentials from the change payload of unrelated deploy edits", () => {
       const current = environmentConfigToGraph({
         services: { web: {


### PR DESCRIPTION
Apply partial credential rotations, explicitly clear credentials on image-to-GitHub switches, preserve bucket group membership on import, and stop silently swallowing domain-read failures.