### PR TITLE
Guard unsupported IaC resources

### DIFF
--- a/docs/railway-config-dsl.md
+++ b/docs/railway-config-dsl.md
@@ -302,13 +302,16 @@ service("web", {
 
 ### Domains
 
+Custom domains are import-only for now. Register the domain in the Railway
+dashboard, then run `railway config pull`; the generated service uses:
+
 ```ts
 service("web", {
   domains: ["app.example.com"],
 });
 ```
 
-Port variant:
+A domain with an explicit target port pulls as:
 
 ```ts
 service("web", {
@@ -316,7 +319,9 @@ service("web", {
 });
 ```
 
-String domains currently default to port `8080`.
+Adding an unregistered domain to source produces a plan diagnostic instead of
+silently attempting product registration. String domains render with port
+`8080`, the current imported default.
 
 ### TCP proxies
 
@@ -500,6 +505,10 @@ const backend = group("Backend", { color: "blue" });
 ```
 
 When passed resources, `group()` returns the group plus those resources with group membership attached, so `resources: [group("Backend", [api, worker])]` is valid.
+
+Volumes cannot be grouped independently because the canvas places a volume with
+its attached service. `group()` rejects volume nodes at compile time and runtime;
+group the attached service instead.
 
 ## Variables and references
 

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -102,6 +102,7 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
       continue;
     }
     if (!previous) {
+      diagnoseUnsupportedCustomDomains({ resource, diagnostics });
       changes.push({
         kind: "resource.create",
         address: resource.address,
@@ -129,7 +130,7 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
       diffTopLevelField({ previous, resource, field: "deploy", changes });
     }
     diffTopLevelField({ previous, resource, field: "groupId", changes });
-    diffNetworking({ previous, resource, changes });
+    diffNetworking({ previous, resource, changes, diagnostics });
     // Volume lifecycle is not part of v0 authoring. Never plan an accidental unmount just
     // because imported config omitted a Railway-owned volume id.
     if (previous.type === "bucket" && resource.type === "bucket" && bucketRegion(previous) !== bucketRegion(resource)) {
@@ -299,30 +300,36 @@ function diffVariables({ previous, resource, changes, resourcesByAddress, reveal
   }
 }
 
-function diffNetworking({ previous, resource, changes }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[] }) {
+function diffNetworking({ previous, resource, changes, diagnostics }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[]; diagnostics: ChangeDiagnostic[] }) {
   const before = "networking" in previous ? previous.networking : undefined;
   const after = "networking" in resource ? resource.networking : undefined;
   const beforeDomains = before?.customDomains ?? {};
-  const afterDomains = after?.customDomains ?? {};
-
-  for (const [domain, config] of Object.entries(afterDomains)) {
-    if (beforeDomains[domain]) continue;
-    changes.push({
-      kind: "domain.create",
-      address: resource.address,
-      domain,
-      ...(config?.port !== undefined && config.port !== null ? { targetPort: config.port } : {}),
-      path: `resources.${resource.address}.domains.${domain}`,
-      summary: `Create custom domain ${resource.name}.${domain}`,
-      severity: "safe",
-      deployEffect: "none",
-    });
-  }
+  diagnoseUnsupportedCustomDomains({ resource, diagnostics, existingDomains: beforeDomains });
 
   const normalizedBefore = normalizeForDiff("networking", { ...before, customDomains: undefined, serviceDomains: undefined });
   const normalizedAfter = normalizeForDiff("networking", { ...after, customDomains: undefined, serviceDomains: undefined });
   if (stableStringify(normalizedBefore) !== stableStringify(normalizedAfter)) {
-    changes.push(update(resource.address, "networking", before, after, `Update ${resource.name} networking`));
+    changes.push(update(resource.address, "networking", normalizedBefore, normalizedAfter, `Update ${resource.name} networking`));
+  }
+}
+
+function diagnoseUnsupportedCustomDomains({
+  resource,
+  diagnostics,
+  existingDomains = {},
+}: {
+  resource: ResourceNode;
+  diagnostics: ChangeDiagnostic[];
+  existingDomains?: Record<string, unknown>;
+}) {
+  const desiredDomains = ("networking" in resource ? resource.networking : undefined)?.customDomains ?? {};
+  for (const domain of Object.keys(desiredDomains)) {
+    if (existingDomains[domain]) continue;
+    diagnostics.push({
+      severity: "error",
+      path: `resources.${resource.address}.domains.${domain}`,
+      message: `Custom-domain registration is not supported by Railway configuration. Add ${domain} in the dashboard, then run railway config pull.`,
+    });
   }
 }
 

--- a/src/iac/graph.ts
+++ b/src/iac/graph.ts
@@ -117,6 +117,8 @@ export interface Edge {
   key?: string;
 }
 
+export type GroupableResourceNode = Exclude<ResourceNode, VolumeNode>;
+export type GroupableResourceInput = GroupableResourceNode | GroupableResourceNode[];
 export type ProjectResourceInput = ResourceNode | ResourceNode[];
 
 export interface ProjectDefinition {

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -4,6 +4,8 @@ import type {
   BucketNode,
   DatabaseNode,
   GroupNode,
+  GroupableResourceInput,
+  GroupableResourceNode,
   ProjectDefinition,
   ProjectResourceInput,
   ResourceNode,
@@ -224,17 +226,21 @@ export function bucket(name: string, config: BucketConfig = {}): BucketNode {
   return { address: resourceAddress("bucket", name) as `bucket.${string}`, type: "bucket", name, config };
 }
 
-export function group(name: string, resources: ProjectResourceInput[], options?: Omit<GroupNode, "address" | "type" | "name">): ResourceNode[];
+export function group(name: string, resources: GroupableResourceInput[], options?: Omit<GroupNode, "address" | "type" | "name">): GroupableResourceNode[];
 export function group(name: string, options?: Omit<GroupNode, "address" | "type" | "name">): GroupNode;
 export function group(
   name: string,
-  resourcesOrOptions: ProjectResourceInput[] | Omit<GroupNode, "address" | "type" | "name"> = {},
+  resourcesOrOptions: GroupableResourceInput[] | Omit<GroupNode, "address" | "type" | "name"> = {},
   maybeOptions: Omit<GroupNode, "address" | "type" | "name"> = {},
-): GroupNode | ResourceNode[] {
-  const resources = Array.isArray(resourcesOrOptions) ? resourcesOrOptions.flat() : undefined;
+): GroupNode | GroupableResourceNode[] {
+  const resources = Array.isArray(resourcesOrOptions) ? resourcesOrOptions.flat(Infinity) as GroupableResourceNode[] : undefined;
   const options = Array.isArray(resourcesOrOptions) ? maybeOptions : resourcesOrOptions;
   const node: GroupNode = { address: resourceAddress("group", name) as `group.${string}`, type: "group", name, ...options };
   if (!resources) return node;
+  const volume = (resources as ResourceNode[]).find(resource => resource.type === "volume");
+  if (volume) {
+    throw new Error(`Volume "${volume.name}" cannot be grouped independently; group its attached service instead.`);
+  }
   return [node, ...resources.map(resource => ({ ...resource, groupId: name }))];
 }
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, image, postgres, project, redis, service, volume } from "../src/index.js";
+import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, group, image, postgres, project, redis, service, volume } from "../src/index.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
 import { changeSetToEnvironmentPatch, RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { runRailwayIac } from "../src/iac/runner.js";
@@ -205,6 +205,43 @@ describe("Railway IaC", () => {
     }));
 
     expect(diffGraphs({ current, desired }).changes).toEqual([]);
+  });
+
+  it("rejects independently grouped volumes", () => {
+    expect(() => {
+      // @ts-expect-error Volumes inherit placement from their attached service.
+      group("Storage", [volume("data")]);
+    }).toThrow('Volume "data" cannot be grouped independently');
+  });
+
+  it("diagnoses unsupported custom-domain registration", () => {
+    const current = environmentConfigToGraph({ services: {} }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: ["app.example.com"] })],
+    }));
+
+    const result = diffGraphs({ current, desired });
+    expect(result.changes).not.toContainEqual(expect.objectContaining({ kind: "domain.create" }));
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      severity: "error",
+      path: "resources.service.web.domains.app.example.com",
+      message: expect.stringContaining("not supported"),
+    }));
+  });
+
+  it("keeps existing custom domains plan-clean", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: {} } },
+      {
+        projectName: "app",
+        customDomainsByServiceId: { web: { "app.example.com": {} } },
+      },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: ["app.example.com"] })],
+    }));
+
+    expect(diffGraphs({ current, desired })).toMatchObject({ changes: [], diagnostics: [] });
   });
 
   it("typechecks known bucket regions", () => {


### PR DESCRIPTION
Reject custom-domain registration and independent volume grouping so unsupported changes fail explicitly.