### PR TITLE
Validate IaC image auto updates

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -347,6 +347,10 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
   let before = (previous as unknown as Record<string, unknown>)[field];
   let after = (resource as unknown as Record<string, unknown>)[field];
   if (field === "source" && previous.type === "database" && isEquivalentDatabaseSource(previous, after)) return;
+  if (field === "source" && resource.type === "service" && !sourceSupportsAutoUpdates(resource.source)) {
+    before = withoutAutoUpdates(before);
+    after = withoutAutoUpdates(after);
+  }
   if (field === "deploy") [before, after] = stripWriteOnlyRegistryCredentials(before, after);
   const normalizedBefore = normalizeForDiff(field, before);
   const normalizedAfter = normalizeForDiff(field, after);
@@ -488,6 +492,20 @@ function stripWriteOnlyRegistryCredentials(before: unknown, after: unknown): [un
   const strippedBefore = beforeCredentials === undefined ? before : withCredentials(before, undefined);
   const strippedAfter = desiredCredentials === undefined ? desiredSide : withCredentials(desiredSide, undefined);
   return [strippedBefore, strippedAfter];
+}
+
+function sourceSupportsAutoUpdates(source: ServiceNode["source"]): boolean {
+  if (source?.type !== "image" || !source.image) return false;
+  if (!source.image.includes("/")) return true;
+  const registry = source.image.split("/", 1)[0] ?? "";
+  return ((!registry.includes(".") && !registry.includes(":") && registry !== "localhost") || registry === "docker.io" || registry === "ghcr.io");
+}
+
+function withoutAutoUpdates(source: unknown): unknown {
+  if (source == null || typeof source !== "object") return source;
+  const copy = { ...(source as Record<string, unknown>) };
+  delete copy.autoUpdates;
+  return Object.keys(copy).length === 0 ? undefined : copy;
 }
 
 function withoutRegistryCredentials(deploy: unknown): unknown {

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -496,8 +496,10 @@ function stripWriteOnlyRegistryCredentials(before: unknown, after: unknown): [un
 
 function sourceSupportsAutoUpdates(source: ServiceNode["source"]): boolean {
   if (source?.type !== "image" || !source.image) return false;
-  if (!source.image.includes("/")) return true;
-  const registry = source.image.split("/", 1)[0] ?? "";
+  const normalized = source.image.trim().toLowerCase();
+  if (normalized === "") return false;
+  if (!normalized.includes("/")) return true;
+  const registry = normalized.split("/", 1)[0] ?? "";
   return ((!registry.includes(".") && !registry.includes(":") && registry !== "localhost") || registry === "docker.io" || registry === "ghcr.io");
 }
 

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -136,12 +136,32 @@ export function environmentConfigToGraph(
   options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; bucketGroupIdsById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
 ): RailwayGraph {
   const resources: ResourceNode[] = [];
+  const groups = config.groups ?? {};
   const groupNamesById = Object.fromEntries(
-    Object.entries(config.groups ?? {}).map(([groupId, groupConfig]) => [groupId, groupConfig?.name ?? groupId]),
+    Object.entries(groups).map(([groupId, groupConfig]) => [groupId, groupConfig?.name ?? groupId]),
   );
+  // Canvas groups are project-scoped, while an imported graph is environment-scoped.
+  // Include only groups referenced by resources in this environment (plus their parent
+  // chain), otherwise groups created in another environment leak into pull as empty
+  // groups and a subsequent apply proposes deleting them.
+  const referencedGroupIds = new Set<string>();
+  for (const service of Object.values(config.services ?? {})) {
+    if (service?.groupId) referencedGroupIds.add(service.groupId);
+  }
+  for (const [bucketId, bucketConfig] of Object.entries(config.buckets ?? {})) {
+    const groupId = options.bucketGroupIdsById?.[bucketId] ?? (bucketConfig as { groupId?: string | null } | null)?.groupId;
+    if (groupId) referencedGroupIds.add(groupId);
+  }
+  for (const groupId of [...referencedGroupIds]) {
+    let parentGroupId = (groups[groupId] as { groupId?: string | null } | null | undefined)?.groupId;
+    while (parentGroupId && !referencedGroupIds.has(parentGroupId)) {
+      referencedGroupIds.add(parentGroupId);
+      parentGroupId = (groups[parentGroupId] as { groupId?: string | null } | null | undefined)?.groupId;
+    }
+  }
 
-  for (const [groupId, groupConfig] of Object.entries(config.groups ?? {})) {
-    if (groupConfig == null || groupConfig.isDeleted) continue;
+  for (const [groupId, groupConfig] of Object.entries(groups)) {
+    if (groupConfig == null || groupConfig.isDeleted || !referencedGroupIds.has(groupId)) continue;
     const name = groupConfig.name ?? groupId;
     const parentGroupId = (groupConfig as { groupId?: string | null }).groupId;
     resources.push(pruneEmpty({

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -129,12 +129,24 @@ export type SharedVariableRef = { readonly [name: string]: VariableValue } & { r
 export type ReferencableServiceNode<K extends string = RailwayProvidedVariable | string> = ServiceNode & { readonly env: ServiceVariableRef<K> };
 export type ReferencableDatabaseNode<E extends DatabaseNode["engine"]> = DatabaseNode & { readonly env: ServiceVariableRef<DatabaseVariable<E>> };
 
-export function github(repo: string, options: Omit<SourceConfig, "type" | "repo" | "image"> = {}): SourceConfig {
+export function github(repo: string, options: Omit<SourceConfig, "type" | "repo" | "image" | "autoUpdates"> = {}): SourceConfig {
+  if ((options as { autoUpdates?: unknown }).autoUpdates !== undefined) {
+    throw new Error("Image auto updates are only supported for Docker image sources.");
+  }
   return { type: "github", repo, branch: options.branch ?? "main", ...options };
 }
 
 export function image(imageName: string, options: Pick<SourceConfig, "rootDirectory" | "autoUpdates"> = {}): SourceConfig {
+  if (options.autoUpdates !== undefined && !supportsImageAutoUpdates(imageName)) {
+    throw new Error("Image auto updates are only supported for Docker Hub and GHCR images.");
+  }
   return { type: "image", image: imageName, ...options };
+}
+
+function supportsImageAutoUpdates(imageName: string): boolean {
+  if (!imageName.includes("/")) return true;
+  const registry = imageName.split("/", 1)[0] ?? "";
+  return (!registry.includes(".") && !registry.includes(":") && registry !== "localhost") || registry === "docker.io" || registry === "ghcr.io";
 }
 
 export function template(templateName: string, options: Omit<SourceConfig, "type" | "template"> = {}): SourceConfig {

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -144,8 +144,10 @@ export function image(imageName: string, options: Pick<SourceConfig, "rootDirect
 }
 
 function supportsImageAutoUpdates(imageName: string): boolean {
-  if (!imageName.includes("/")) return true;
-  const registry = imageName.split("/", 1)[0] ?? "";
+  const normalized = imageName.trim().toLowerCase();
+  if (normalized === "") return false;
+  if (!normalized.includes("/")) return true;
+  const registry = normalized.split("/", 1)[0] ?? "";
   return (!registry.includes(".") && !registry.includes(":") && registry !== "localhost") || registry === "docker.io" || registry === "ghcr.io";
 }
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -662,6 +662,25 @@ describe("Railway IaC", () => {
     });
   });
 
+  it("rejects auto updates outside Docker Hub and GHCR image sources", () => {
+    expect(() => github("acme/api", { autoUpdates: { type: "patch" } } as never)).toThrow(/Docker image sources/);
+    expect(() => image("registry.example.com/acme/api:1", { autoUpdates: { type: "patch" } })).toThrow(/Docker Hub and GHCR/);
+    expect(() => image("ubuntu:24.04", { autoUpdates: { type: "patch" } })).not.toThrow();
+    expect(() => image("docker.io/library/ubuntu:24.04", { autoUpdates: { type: "patch" } })).not.toThrow();
+    expect(() => image("ghcr.io/acme/api:1", { autoUpdates: { type: "patch" } })).not.toThrow();
+  });
+
+  it("preserves stale auto updates on non-image sources without planning drift", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "acme/api", branch: "main", autoUpdates: { type: "patch", schedule: [] } } } },
+    }, { projectName: "app", serviceNamesById: { web: "web" } });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("acme/api") })],
+    }));
+
+    expect(diffGraphs({ current, desired }).changes).toEqual([]);
+  });
+
   it("refuses to manage a service still owned by railway.json/toml", () => {
     const current = environmentConfigToGraph({
       services: { web: { source: { repo: "r" }, configFile: "railway.json" } },

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -694,6 +694,25 @@ describe("Railway IaC", () => {
     }));
   });
 
+  it("omits project canvas groups unreferenced by the imported environment", () => {
+    const graph = environmentConfigToGraph({
+      groups: {
+        production: { name: "Production" },
+        test: { name: "Test-only Sandbox" },
+      },
+      services: {
+        web: { source: { image: "nginx:latest" }, groupId: "production" },
+      },
+    }, { projectName: "app", serviceNamesById: { web: "web" } });
+
+    expect(graph.resources).toContainEqual(expect.objectContaining({
+      address: "group.Production",
+    }));
+    expect(graph.resources).not.toContainEqual(expect.objectContaining({
+      address: "group.Test-only Sandbox",
+    }));
+  });
+
   it("flags a bucket region change as an immutable-region error", () => {
     const current = environmentConfigToGraph({ buckets: { assets: { region: "sjc" } } }, { projectName: "app" });
     const desired = projectDefinitionToGraph(project("app", { resources: [bucket("assets", { region: "ams" })] }));

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -668,6 +668,8 @@ describe("Railway IaC", () => {
     expect(() => image("ubuntu:24.04", { autoUpdates: { type: "patch" } })).not.toThrow();
     expect(() => image("docker.io/library/ubuntu:24.04", { autoUpdates: { type: "patch" } })).not.toThrow();
     expect(() => image("ghcr.io/acme/api:1", { autoUpdates: { type: "patch" } })).not.toThrow();
+    expect(() => image("GHCR.IO/acme/api:1", { autoUpdates: { type: "patch" } })).not.toThrow();
+    expect(() => image("", { autoUpdates: { type: "patch" } })).toThrow(/Docker Hub and GHCR/);
   });
 
   it("preserves stale auto updates on non-image sources without planning drift", () => {


### PR DESCRIPTION
Allows auto-update policies only for Docker Hub and GHCR image sources and preserves stale unsupported policies without planning destructive cleanup.