### PR TITLE
Support canvas groups for detached volumes

### DIFF
--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -18,6 +18,7 @@ export interface CurrentEnvironmentResult {
   configEtag?: string | undefined;
   serviceNamesById: Record<string, string>;
   volumeNamesById: Record<string, string>;
+  volumeGroupIdsById: Record<string, string>;
   bucketNamesById: Record<string, string>;
   bucketGroupIdsById: Record<string, string>;
   customDomainsByServiceId: Record<string, Record<string, { port?: number }>>;
@@ -72,9 +73,9 @@ export class IacClient {
 
   async getCurrentEnvironment(environmentId: string, options: { decryptVariables?: boolean } = {}): Promise<CurrentEnvironmentResult> {
     const data = await gql<{
-      environment: { id: string; name?: string; projectId?: string; config: EnvironmentConfig; configEtag?: string };
+      environment: { id: string; name?: string; projectId?: string; config: EnvironmentConfig; configEtag?: string; canvasGroupRefs?: Record<string, string> };
     }, { environmentId: string; decryptVariables: boolean }>(this.#config, `query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
-      environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag }
+      environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs }
     }`, { environmentId, decryptVariables: options.decryptVariables ?? false });
 
     const projectName = data.environment.projectId ? await this.getProjectName(data.environment.projectId) : undefined;
@@ -90,6 +91,10 @@ export class IacClient {
       config: data.environment.config ?? {},
       serviceNamesById: Object.fromEntries(services.map(service => [service.id, service.name])),
       volumeNamesById: Object.fromEntries(volumes.flatMap(volume => volume.name ? [[volume.id, volume.name] as const] : [])),
+      volumeGroupIdsById: Object.fromEntries(volumes.flatMap(volume => {
+        const groupId = data.environment.canvasGroupRefs?.[volume.id];
+        return groupId ? [[volume.id, groupId] as const] : [];
+      })),
       bucketNamesById: Object.fromEntries(buckets.map(bucket => [bucket.id, bucket.name])),
       bucketGroupIdsById: Object.fromEntries(buckets.flatMap(bucket => bucket.groupId ? [[bucket.id, bucket.groupId] as const] : [])),
       customDomainsByServiceId,

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -133,7 +133,7 @@ export function graphToEnvironmentConfig(graph: RailwayGraph, options: GraphComp
 
 export function environmentConfigToGraph(
   config: EnvironmentConfig,
-  options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; bucketNamesById?: Record<string, string>; bucketGroupIdsById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
+  options: { projectName?: string; serviceNamesById?: Record<string, string>; volumeNamesById?: Record<string, string>; volumeGroupIdsById?: Record<string, string>; bucketNamesById?: Record<string, string>; bucketGroupIdsById?: Record<string, string>; customDomainsByServiceId?: Record<string, Record<string, { port?: number }>> } = {},
 ): RailwayGraph {
   const resources: ResourceNode[] = [];
   const groups = config.groups ?? {};
@@ -147,6 +147,9 @@ export function environmentConfigToGraph(
   const referencedGroupIds = new Set<string>();
   for (const service of Object.values(config.services ?? {})) {
     if (service?.groupId) referencedGroupIds.add(service.groupId);
+  }
+  for (const groupId of Object.values(options.volumeGroupIdsById ?? {})) {
+    referencedGroupIds.add(groupId);
   }
   for (const [bucketId, bucketConfig] of Object.entries(config.buckets ?? {})) {
     const groupId = options.bucketGroupIdsById?.[bucketId] ?? (bucketConfig as { groupId?: string | null } | null)?.groupId;
@@ -216,11 +219,13 @@ export function environmentConfigToGraph(
   for (const [volumeId, volumeConfig] of Object.entries(config.volumes ?? {})) {
     if (volumeConfig == null || volumeConfig.isDeleted) continue;
     const name = options.volumeNamesById?.[volumeId] ?? volumeId;
+    const groupId = options.volumeGroupIdsById?.[volumeId];
     resources.push({
       address: resourceAddress("volume", name) as `volume.${string}`,
       type: "volume",
       name,
       config: volumeConfig,
+      ...(groupId ? { groupId: groupNamesById[groupId] ?? groupId } : {}),
     });
   }
 

--- a/src/iac/graph.ts
+++ b/src/iac/graph.ts
@@ -117,7 +117,7 @@ export interface Edge {
   key?: string;
 }
 
-export type GroupableResourceNode = Exclude<ResourceNode, VolumeNode>;
+export type GroupableResourceNode = ResourceNode;
 export type GroupableResourceInput = GroupableResourceNode | GroupableResourceNode[];
 export type ProjectResourceInput = ResourceNode | ResourceNode[];
 

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -265,6 +265,7 @@ function graphFromCurrentEnvironment(current: CurrentEnvironmentResult, desiredG
     projectName: current.projectName ?? desiredGraph.project.name,
     serviceNamesById: current.serviceNamesById,
     volumeNamesById: current.volumeNamesById,
+    volumeGroupIdsById: current.volumeGroupIdsById,
     bucketNamesById: current.bucketNamesById,
     bucketGroupIdsById: current.bucketGroupIdsById,
     customDomainsByServiceId: current.customDomainsByServiceId,

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -251,10 +251,6 @@ export function group(
   const options = Array.isArray(resourcesOrOptions) ? maybeOptions : resourcesOrOptions;
   const node: GroupNode = { address: resourceAddress("group", name) as `group.${string}`, type: "group", name, ...options };
   if (!resources) return node;
-  const volume = (resources as ResourceNode[]).find(resource => resource.type === "volume");
-  if (volume) {
-    throw new Error(`Volume "${volume.name}" cannot be grouped independently; group its attached service instead.`);
-  }
   return [node, ...resources.map(resource => ({ ...resource, groupId: name }))];
 }
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -207,11 +207,12 @@ describe("Railway IaC", () => {
     expect(diffGraphs({ current, desired }).changes).toEqual([]);
   });
 
-  it("rejects independently grouped volumes", () => {
-    expect(() => {
-      // @ts-expect-error Volumes inherit placement from their attached service.
-      group("Storage", [volume("data")]);
-    }).toThrow('Volume "data" cannot be grouped independently');
+  it("supports independently grouped volumes", () => {
+    const resources = group("Storage", [volume("data")]);
+    expect(resources).toContainEqual(expect.objectContaining({
+      address: "volume.data",
+      groupId: "Storage",
+    }));
   });
 
   it("diagnoses unsupported custom-domain registration", () => {
@@ -694,6 +695,25 @@ describe("Railway IaC", () => {
     const { changes, diagnostics } = diffGraphs({ current, desired });
     expect(diagnostics).toContainEqual(expect.objectContaining({ severity: "error", message: expect.stringContaining("railway.json") }));
     expect(changes).toEqual([]);
+  });
+
+  it("restores volume group membership from environment canvas state", () => {
+    const graph = environmentConfigToGraph(
+      {
+        groups: { "group-id": { name: "Storage" } },
+        volumes: { "volume-id": { region: "us-west2", sizeMB: 1024 } },
+      },
+      {
+        projectName: "app",
+        volumeNamesById: { "volume-id": "data" },
+        volumeGroupIdsById: { "volume-id": "group-id" },
+      },
+    );
+
+    expect(graph.resources).toContainEqual(expect.objectContaining({
+      address: "volume.data",
+      groupId: "Storage",
+    }));
   });
 
   it("restores bucket group membership from project canvas state", () => {


### PR DESCRIPTION
Allows volumes as group members and restores volume group membership from environment canvas state during pull.