### PR TITLE
IaC: limits DSL for per-container resource limits + fix unauthored limitOverride churn

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -361,9 +361,10 @@ function diffTopLevelField({ previous, resource, field, changes }: { previous: R
 function diffServiceDeploy({ previous, resource, changes }: { previous: ServiceNode; resource: ServiceNode; changes: RailwayChange[] }) {
   const desiredDeploy = serviceDeployWithCurrentRegion(previous.deploy, resource.deploy);
   const switchingAwayFromImage = previous.source?.type === "image" && resource.source?.type !== "image";
-  const [before, after] = switchingAwayFromImage && previous.deploy?.registryCredentials !== undefined
+  let [before, after] = switchingAwayFromImage && previous.deploy?.registryCredentials !== undefined
     ? [withoutRegistryCredentials(previous.deploy), { ...(desiredDeploy ?? {}), registryCredentials: null }]
     : stripWriteOnlyRegistryCredentials(previous.deploy, desiredDeploy);
+  before = dropUnauthoredPlatformFields(before, after, ["limitOverride"]) as ServiceNode["deploy"];
   const normalizedBefore = normalizeForDiff("deploy", before);
   const normalizedAfter = normalizeForDiff("deploy", after);
   if (stableStringify(normalizedBefore) === stableStringify(normalizedAfter)) return;
@@ -406,6 +407,7 @@ function diffVolumeConfig({ previous, resource, changes }: { previous: VolumeNod
 function diffDatabaseDeploy({ previous, resource, changes }: { previous: DatabaseNode; resource: DatabaseNode; changes: RailwayChange[] }) {
   let [previousDeploy, resourceDeploy] = stripWriteOnlyRegistryCredentials(previous.deploy, resource.deploy);
   previousDeploy = dropPlatformStartCommand(previousDeploy, resourceDeploy);
+  previousDeploy = dropUnauthoredPlatformFields(previousDeploy, resourceDeploy, ["limitOverride"]);
   const previousRegion = databaseRegion(previous);
   const desiredRegion = databaseRegion(resource);
   if (desiredRegion !== undefined && desiredRegion !== previousRegion) {
@@ -427,8 +429,9 @@ function diffDatabaseDeploy({ previous, resource, changes }: { previous: Databas
 }
 
 // Fields Backboard realizes outside authored config (template start commands with
-// auth flags, volume alert thresholds, resize capability). Diffing them against a
-// config that never authored them plans unsets that strip live behavior — so a
+// auth flags, volume alert thresholds, resize capability, resource limits set via
+// the dashboard or serviceInstanceLimitsUpdate). Diffing them against a config
+// that never authored them plans unsets that strip live behavior — so a
 // current-side value is only diffed when the author wrote one.
 function dropUnauthoredPlatformFields(previousValue: unknown, desiredValue: unknown, fields: string[]): unknown {
   if (previousValue == null || typeof previousValue !== "object") return previousValue;

--- a/src/iac/compiler.ts
+++ b/src/iac/compiler.ts
@@ -291,6 +291,7 @@ function databaseDeploy(database: DatabaseNode, requiredMountPath: string): Depl
   return {
     requiredMountPath,
     ...(database.deploy?.multiRegionConfig ? { multiRegionConfig: database.deploy.multiRegionConfig } : {}),
+    ...(database.deploy?.limitOverride ? { limitOverride: database.deploy.limitOverride } : {}),
   };
 }
 

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -70,6 +70,16 @@ export function createRailwayContext(input: RailwayContextInput = {}): RailwayCo
 
 export type RegionConfig = number | { count?: number; replicas?: number; stacker?: string | null };
 
+/**
+ * Per-container resource limits. Compiles to `deploy.limitOverride.containers`
+ * and mirrors the platform fields verbatim — no unit conversion.
+ */
+export interface ServiceLimits {
+  cpu?: number;
+  memoryBytes?: number;
+  diskBytes?: number;
+}
+
 export interface IntentServiceConfig {
   source?: SourceConfig | Omit<SourceConfig, "type">;
   root?: string;
@@ -86,6 +96,7 @@ export interface IntentServiceConfig {
   healthcheckTimeout?: number;
   replicas?: number | Record<string, RegionConfig>;
   regions?: Record<string, RegionConfig>;
+  limits?: ServiceLimits;
   networking?: ServiceNetworking;
   domains?: Array<string | { domain: string; port?: number }>;
   tcp?: Array<string | number>;
@@ -188,6 +199,7 @@ export function fn<const Env extends Record<string, string | VariableConfig | Va
 
 export interface DatabaseConfig {
   region?: string;
+  limits?: ServiceLimits;
 }
 
 export function postgres(name: string, config: DatabaseConfig = {}): ReferencableDatabaseNode<"postgres"> {
@@ -214,9 +226,14 @@ export function mongo(name: string, config: DatabaseConfig = {}): ReferencableDa
 export function database<E extends DatabaseNode["engine"]>(
   name: string,
   engine: E,
-  options: { image: string; output?: string; defaultMountPath?: string; region?: string },
+  options: { image: string; output?: string; defaultMountPath?: string; region?: string; limits?: ServiceLimits },
 ): ReferencableDatabaseNode<E> {
   const output = options.output ?? "DATABASE_URL";
+  const limitOverride = normalizeLimits(options.limits);
+  const deploy = pruneEmpty({
+    ...(options.region ? { multiRegionConfig: { [options.region]: { numReplicas: 1 } } } : {}),
+    ...(limitOverride ? { limitOverride } : {}),
+  });
   const node = {
     address: resourceAddress("database", name) as `database.${string}`,
     type: "database",
@@ -227,7 +244,7 @@ export function database<E extends DatabaseNode["engine"]>(
     output,
     defaultMountPath: options.defaultMountPath,
     source: image(options.image),
-    ...(options.region ? { deploy: { multiRegionConfig: { [options.region]: { numReplicas: 1 } } } } : {}),
+    ...(deploy ? { deploy } : {}),
   } as DatabaseNode;
   return withVariableRefs(node) as ReferencableDatabaseNode<E>;
 }
@@ -315,9 +332,16 @@ function normalizeDeploy(config: ServiceConfigInput): DeployConfig | undefined {
     preDeployCommand: Array.isArray(preDeployCommand) ? preDeployCommand : preDeployCommand ? [preDeployCommand] : config.deploy?.preDeployCommand,
     healthcheckPath: config.healthcheck ?? config.healthcheckPath ?? config.run?.healthcheck ?? config.deploy?.healthcheckPath,
     healthcheckTimeout: config.healthcheckTimeout ?? config.run?.healthcheckTimeout ?? config.deploy?.healthcheckTimeout,
+    limitOverride: normalizeLimits(config.limits) ?? config.deploy?.limitOverride,
     ...replicaConfig,
     multiRegionConfig: replicaConfig?.multiRegionConfig ?? config.deploy?.multiRegionConfig,
   }) as DeployConfig | undefined;
+}
+
+function normalizeLimits(limits: ServiceLimits | undefined): DeployConfig["limitOverride"] | undefined {
+  if (!limits) return undefined;
+  const containers = pruneEmpty({ ...limits });
+  return containers ? { containers } : undefined;
 }
 
 function normalizeReplicas(replicas: ServiceConfigInput["replicas"], regions: ServiceConfigInput["regions"]): Pick<DeployConfig, "numReplicas" | "multiRegionConfig"> | undefined {

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -249,6 +249,92 @@ describe("Railway IaC", () => {
     expect(bucket("assets", { region: "sjc" }).config?.region).toBe("sjc");
   });
 
+  it("maps service limits to deploy.limitOverride", () => {
+    const graph = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { limits: { cpu: 2, memoryBytes: 1_000_000_000 } })],
+    }));
+
+    expect(graphToEnvironmentConfig(graph).services?.web?.deploy).toEqual({
+      limitOverride: { containers: { cpu: 2, memoryBytes: 1_000_000_000 } },
+    });
+  });
+
+  it("maps database limits alongside region placement", () => {
+    const graph = projectDefinitionToGraph(project("app", {
+      resources: [redis("cache", { region: "us-east4", limits: { cpu: 1, memoryBytes: 500_000_000 } })],
+    }));
+
+    expect(graphToEnvironmentConfig(graph).services?.cache?.deploy).toMatchObject({
+      multiRegionConfig: { "us-east4": { numReplicas: 1 } },
+      limitOverride: { containers: { cpu: 1, memoryBytes: 500_000_000 } },
+    });
+  });
+
+  // Limits are routinely set outside repo config (dashboard, serviceInstanceLimitsUpdate).
+  // A config that never authored them must not plan an unset that strips live limits.
+  it("does not churn unauthored service resource limits", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: { deploy: { limitOverride: { containers: { cpu: 2, memoryBytes: 1_000_000_000 } } } } } },
+      { projectName: "app" },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", {})],
+    }));
+
+    expect(diffGraphs({ current, desired })).toMatchObject({ changes: [], diagnostics: [] });
+  });
+
+  it("does not churn unauthored database resource limits", () => {
+    const current = environmentConfigToGraph(
+      {
+        services: {
+          cache: {
+            source: { image: "railwayapp/redis:8.2" },
+            deploy: { limitOverride: { containers: { cpu: 1, memoryBytes: 500_000_000 } } },
+          },
+        },
+      },
+      { projectName: "app" },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [redis("cache")],
+    }));
+
+    const limitChanges = diffGraphs({ current, desired }).changes
+      .filter(change => JSON.stringify(change).includes("limitOverride"));
+    expect(limitChanges).toEqual([]);
+  });
+
+  it("still diffs authored limits against current limits", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: { deploy: { limitOverride: { containers: { cpu: 1, memoryBytes: 500_000_000 } } } } } },
+      { projectName: "app" },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { limits: { cpu: 2, memoryBytes: 1_000_000_000 } })],
+    }));
+
+    const changeSet = diffGraphs({ current, desired });
+    expect(changeSet.changes).toHaveLength(1);
+    expect(changeSet.changes[0]).toMatchObject({
+      kind: "resource.update",
+      address: "service.web",
+    });
+  });
+
+  it("plans no changes for round-tripped limits", () => {
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [
+        service("web", { source: image("ghcr.io/acme/web:1.0.0"), limits: { cpu: 2, memoryBytes: 1_000_000_000 } }),
+        redis("cache", { limits: { cpu: 1, memoryBytes: 500_000_000 } }),
+      ],
+    }));
+
+    const current = environmentConfigToGraph(graphToEnvironmentConfig(desired), { projectName: "app" });
+
+    expect(diffGraphs({ current, desired }).changes).toEqual([]);
+  });
+
   // The GA gate: compiling a desired graph to config and reading it straight back
   // must produce zero changes. This is the "import → plan → ∅" round-trip the
   // runner performs against a live environment.


### PR DESCRIPTION
Closes #57

## What

1. **Feature — `limits` sugar**: `service()`, `fn()`, and the database helpers (`postgres`/`mysql`/`redis`/`mongo`) accept

   ```ts
   const web = service("web", {
     source: image("chatwoot/chatwoot:v4.16.1"),
     limits: { cpu: 2, memoryBytes: 1_000_000_000 },
   });
   const cache = redis("redis", { limits: { cpu: 1, memoryBytes: 500_000_000 } });
   ```

   compiling to `deploy.limitOverride.containers` with the platform field names verbatim (`cpu`, `memoryBytes`, `diskBytes`) — no unit conversion. `databaseDeploy` in the compiler now carries `limitOverride` through to environment config (it previously cherry-picked only `multiRegionConfig`).

2. **Bug fix — unauthored `limitOverride` churn**: limits set outside repo config (dashboard or `serviceInstanceLimitsUpdate`) land in the environment config's `deploy.limitOverride`, and a `railway.ts` that never authored them planned an **unset** — `railway config apply` would silently strip live resource limits. Reproduced on a real project (SDK 3.6.0 / CLI 5.28.1):

   ```
   Plan: 0 to add, 6 to change, 0 to destroy
     ~ Update postgres deploy.limitOverride.containers.cpu, deploy.limitOverride.containers.memoryBytes
       └ deploy.limitOverride.containers.cpu (2 → unset)
       └ deploy.limitOverride.containers.memoryBytes (1000000000 → unset)
     ...
   ```

   Fixed by treating a current-side `limitOverride` the author never wrote as platform-owned via the existing `dropUnauthoredPlatformFields` mechanism (same treatment as template-realized `startCommand` and volume alert config). Omission = leave unmanaged; authored limits still diff normally.

## Validation

- 6 new unit tests: sugar mapping (service + database), unauthored no-churn (service + database), authored diff, limits round-trip (`import → plan → ∅`)
- `pnpm run typecheck`, `pnpm run test` (214 passed), `pnpm run build` all green
- Verified against a live 6-service project: with unauthored limits the plan is clean (was 6 phantom unsets), and after authoring matching `limits` the plan stays clean

Note: `package:check` passes publint + `npm pack` but its smoke test fails locally on Windows only because GNU tar misparses the `E:\` drive prefix as a remote host — unrelated to this change.
