### PR TITLE
IaC: fail apply when the commit workflow fails, and create buckets in the target environment

### DIFF
--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -54,6 +54,21 @@ export interface ChangeSetApplyResult {
   stagedPatchId?: string | null;
 }
 
+export type WorkflowStatus = "Complete" | "Error" | "NotFound" | "Running";
+export interface WorkflowResult {
+  status: WorkflowStatus;
+  error?: string | null;
+}
+
+export interface WaitForWorkflowOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
 export interface ProjectService { id: string; name: string }
 export interface ProjectVolume { id: string; name?: string | null; serviceId?: string | null }
 export interface ProjectBucket { id: string; name: string; groupId?: string | null }
@@ -169,7 +184,7 @@ export class IacClient {
       }
     }
 
-    const bucketIdsByName = await this.ensureGraphBuckets({ projectId, graph });
+    const bucketIdsByName = await this.ensureGraphBuckets({ projectId, environmentId, graph });
     return { serviceIdsByName, volumeIdsByServiceName, bucketIdsByName };
   }
 
@@ -206,6 +221,27 @@ export class IacClient {
     }
   }
 
+  async getWorkflowStatus(workflowId: string): Promise<WorkflowResult> {
+    const data = await gql<{ workflowStatus: WorkflowResult }, { workflowId: string }>(this.#config, `query IacWorkflowStatus($workflowId: String!) {
+      workflowStatus(workflowId: $workflowId) { status error }
+    }`, { workflowId });
+    return data.workflowStatus;
+  }
+
+  // environmentApplyChangeSet returns as soon as the patch is staged and the
+  // commit workflow is queued; the commit itself runs asynchronously and can
+  // fail afterwards (an invalid value anywhere in the patch rejects the whole
+  // commit). Poll to a terminal state so callers can tell "staged" from "applied".
+  async waitForWorkflow(workflowId: string, { timeoutMs = 120_000, intervalMs = 2_000, now = () => Date.now(), sleep = defaultSleep }: WaitForWorkflowOptions = {}): Promise<WorkflowResult> {
+    const deadline = now() + timeoutMs;
+    for (;;) {
+      const result = await this.getWorkflowStatus(workflowId);
+      if (result.status !== "Running") return result;
+      if (now() >= deadline) return { status: "Running", error: `Timed out after ${timeoutMs}ms waiting for workflow ${workflowId}.` };
+      await sleep(intervalMs);
+    }
+  }
+
   async commitStagedPatch({ environmentId, message, skipDeploys }: { environmentId: string; message?: string; skipDeploys?: boolean }): Promise<string> {
     const variables: { environmentId: string; message?: string; skipDeploys?: boolean } = { environmentId };
     if (message !== undefined) variables.message = message;
@@ -216,19 +252,23 @@ export class IacClient {
     return data.environmentPatchCommitStaged;
   }
 
-  private async ensureGraphBuckets({ projectId, graph }: { projectId: string; graph: RailwayGraph }): Promise<Record<string, string>> {
+  private async ensureGraphBuckets({ projectId, environmentId, graph }: { projectId: string; environmentId: string; graph: RailwayGraph }): Promise<Record<string, string>> {
     const existing = await this.getProjectBuckets(projectId);
     const idsByName = Object.fromEntries(existing.map(bucket => [bucket.name, bucket.id]));
     for (const resource of graph.resources) {
       if (resource.type !== "bucket" || idsByName[resource.name]) continue;
-      const bucket = await this.createBucketForResource({ projectId, name: resource.name });
+      const bucket = await this.createBucketForResource({ projectId, environmentId, name: resource.name });
       idsByName[resource.name] = bucket.id;
     }
     return idsByName;
   }
 
-  private async createBucketForResource({ projectId, name }: { projectId: string; name?: string }): Promise<ProjectBucket> {
-    const input: BucketCreateInput = { projectId, environmentId: null };
+  // environmentId deploys the bucket into the target environment. Creating with a
+  // null environmentId leaves a project-level row that never deploys, is invisible
+  // to `railway bucket list`, and permanently holds the name (there is no bucket
+  // delete API), so a retry can never create the bucket it was asked for.
+  private async createBucketForResource({ projectId, environmentId, name }: { projectId: string; environmentId: string; name?: string }): Promise<ProjectBucket> {
+    const input: BucketCreateInput = { projectId, environmentId };
     if (name !== undefined) input.name = name;
     const data = await gql<{ bucketCreate: ProjectBucket }, { input: BucketCreateInput }>(this.#config, `mutation IacBucketCreate($input: BucketCreateInput!) {
       bucketCreate(input: $input) { id name }

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -1,6 +1,6 @@
 import { diffGraphs, renderChangeSet, type RailwayChangeSet } from "./change-set.js";
 import { environmentConfigToGraph } from "./compiler.js";
-import { IacClient, type ChangeSetApplyResult, type ChangeSetPreviewResult, type CurrentEnvironmentResult } from "./client.js";
+import { IacClient, type ChangeSetApplyResult, type ChangeSetPreviewResult, type CurrentEnvironmentResult, type WorkflowResult } from "./client.js";
 import { validateGraph, type RailwayGraph } from "./graph.js";
 import { evaluateRailwayProject, findRailwayFile } from "./project.js";
 import { renderRailwayGraphTypes } from "./typegen.js";
@@ -89,6 +89,8 @@ export interface RailwayIacStageResponse extends Omit<RailwayIacPlanResponse, "c
 export interface RailwayIacApplyResponse extends Omit<RailwayIacStageResponse, "command"> {
   command: "apply";
   applyResult?: ChangeSetApplyResult;
+  /** Terminal state of the commit workflow. Absent when the apply staged nothing. */
+  workflow?: WorkflowResult;
   deploymentId?: string;
   stagedPatchId?: string;
 }
@@ -241,10 +243,28 @@ async function applyRailwayIac(input: EvaluatedCommandInput): Promise<RailwayIac
     ...(planned.currentEnvironment?.configEtag ? { baseEtag: planned.currentEnvironment.configEtag } : {}),
   });
 
+  // The mutation returns once the patch is staged and the commit workflow is
+  // queued. Without waiting for that workflow, a commit the server rejects
+  // outright still reports every change as "applied" with no diagnostics — the
+  // CLI prints ✓ and the environment is unchanged.
+  const workflow = applyResult.deploymentId ? await client.waitForWorkflow(applyResult.deploymentId) : undefined;
+  const workflowDiagnostics: RailwayIacRunnerDiagnostic[] = workflow && workflow.status !== "Complete"
+    ? [{
+        severity: "error",
+        path: "apply.workflow",
+        message: workflow.status === "Running"
+          ? `Timed out waiting for the commit to finish (workflow ${applyResult.deploymentId}). The changes may still be applying; re-run plan to check.`
+          : `Railway rejected the commit (${workflow.status})${workflow.error ? `: ${workflow.error}` : ""}. No changes were applied.`,
+      }]
+    : [];
+
   return {
     ...planned,
+    ok: planned.ok && workflowDiagnostics.length === 0,
     command: "apply",
     applyResult,
+    ...(workflow ? { workflow } : {}),
+    diagnostics: [...planned.diagnostics, ...workflowDiagnostics],
     ...(applyResult.deploymentId ? { deploymentId: applyResult.deploymentId } : {}),
     ...(applyResult.stagedPatchId ? { stagedPatchId: applyResult.stagedPatchId } : {}),
   };

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -93,6 +93,7 @@ describe("IaC runner — threads configEtag from plan into apply", () => {
       { data: { project: { buckets: { edges: [] } } } },
       { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [{ kind: "resource.create", address: "service.web", resource: { address: "service.web", type: "service", name: "web" }, path: "resources.service.web", summary: "Create service web", severity: "safe", deployEffect: "deploy" }], diagnostics: [] }, diagnostics: [], effects: [] } } },
       { data: { environmentApplyChangeSet: { id: "op_1", status: "applied", changes: [], diagnostics: [], deploymentId: "deploy_1", stagedPatchId: null } } },
+      { data: { workflowStatus: { status: "Complete", error: null } } },
     ]);
     vi.stubGlobal("fetch", mock.fetch);
 
@@ -108,5 +109,98 @@ describe("IaC runner — threads configEtag from plan into apply", () => {
     const applyCall = mock.calls.find(call => call.body.query.includes("environmentApplyChangeSet"));
     expect(applyCall, "expected an environmentApplyChangeSet request").toBeDefined();
     expect((applyCall?.body.variables as Record<string, unknown>).baseConfigEtag).toBe("etag-LIVE");
+  });
+
+  // environmentApplyChangeSet returns "applied" per change as soon as the patch is
+  // staged. When the async commit is then rejected, the apply must not report ✓.
+  it("reports a rejected commit workflow as a failed apply", async () => {
+    const mock = createFetchMock([
+      { data: { environment: { id: "e1", name: "production", projectId: "p1", config: {}, configEtag: "etag-LIVE" } } },
+      { data: { project: { name: "e2e-thread" } } },
+      { data: { project: { services: { edges: [] } } } },
+      { data: { project: { volumes: { edges: [] } } } },
+      { data: { project: { buckets: { edges: [] } } } },
+      { data: { environmentPreviewChangeSet: { changeSet: { version: 1, changes: [{ kind: "resource.create", address: "service.web", resource: { address: "service.web", type: "service", name: "web" }, path: "resources.service.web", summary: "Create service web", severity: "safe", deployEffect: "deploy" }], diagnostics: [] }, diagnostics: [], effects: [] } } },
+      { data: { environmentApplyChangeSet: { id: "op_1", status: "applied", changes: [], diagnostics: [], deploymentId: "deploy_1", stagedPatchId: "patch_1" } } },
+      { data: { workflowStatus: { status: "Error", error: "Max size of 5000 MB on current plan." } } },
+    ]);
+    vi.stubGlobal("fetch", mock.fetch);
+
+    const result = await runRailwayIac({
+      command: "apply",
+      file: fixture,
+      backboard: { token: "t", environmentId: "e1" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        severity: "error",
+        path: "apply.workflow",
+        message: expect.stringContaining("Max size of 5000 MB on current plan."),
+      }),
+    );
+  });
+});
+
+describe("IaC apply — commit workflow verification", () => {
+  it("polls while the workflow is Running and resolves on a terminal state", async () => {
+    const mock = createFetchMock([
+      { data: { workflowStatus: { status: "Running", error: null } } },
+      { data: { workflowStatus: { status: "Running", error: null } } },
+      { data: { workflowStatus: { status: "Complete", error: null } } },
+    ]);
+
+    const result = await client(mock.fetch).waitForWorkflow("wf_1", { intervalMs: 0, sleep: async () => {} });
+
+    expect(result).toEqual({ status: "Complete", error: null });
+    expect(mock.calls).toHaveLength(3);
+  });
+
+  it("gives up with a Running result once the timeout elapses", async () => {
+    const mock = createFetchMock(Array.from({ length: 5 }, () => ({ data: { workflowStatus: { status: "Running", error: null } } })));
+    let clock = 0;
+
+    const result = await client(mock.fetch).waitForWorkflow("wf_1", {
+      timeoutMs: 10,
+      intervalMs: 0,
+      now: () => (clock += 20),
+      sleep: async () => {},
+    });
+
+    expect(result.status).toBe("Running");
+    expect(result.error).toContain("Timed out");
+  });
+});
+
+describe("IaC apply — bucket creation targets the environment", () => {
+  // A bucket created with environmentId: null is a project-level row that never
+  // deploys, never appears in `railway bucket list`, and holds the name forever.
+  it("creates graph buckets in the target environment", async () => {
+    const mock = createFetchMock([
+      { data: { project: { services: { edges: [] } } } },
+      { data: { project: { buckets: { edges: [] } } } },
+      { data: { bucketCreate: { id: "b1", name: "uploads" } } },
+    ]);
+
+    await client(mock.fetch).ensureGraphResources({
+      projectId: "p1",
+      environmentId: "e1",
+      graph: {
+        version: 1,
+        project: { name: "app" },
+        environments: [],
+        resources: [{ address: "bucket.uploads", type: "bucket", name: "uploads" }],
+        edges: [],
+      } as never,
+    });
+
+    const createCall = mock.calls.find(call => call.body.query.includes("bucketCreate"));
+    expect(createCall, "expected a bucketCreate request").toBeDefined();
+    expect((variablesOf(createCall).input as Record<string, unknown>)).toMatchObject({
+      projectId: "p1",
+      environmentId: "e1",
+      name: "uploads",
+    });
   });
 });


### PR DESCRIPTION
Fixes #59. Fixes #60.

Two independent apply-path bugs, both found deploying a 6-service stack with this SDK. Each is small but silent, and both produce "the CLI said ✓ but nothing happened".

## 1. Verify the commit workflow before reporting success (#59)

`environmentApplyChangeSet` returns once the patch is **staged** and the commit workflow is **queued**. The commit runs asynchronously and can be rejected wholesale — one invalid value anywhere in the patch kills it. The runner never observed that workflow, so it reported the mutation's optimistic result: every change `status: "applied"`, `diagnostics: []`, exit 0, environment untouched.

`waitForWorkflow` polls `workflowStatus(workflowId:)` (`Complete | Error | NotFound | Running`) to a terminal state. A non-`Complete` result sets `ok: false` and adds an `apply.workflow` diagnostic carrying the platform's own message — the one that actually explains the failure:

```
Railway rejected the commit (Error): Max size of 5000 MB on current plan. Please select a valid size or upgrade
```

A poll timeout is reported distinctly (changes may still be applying) rather than as a rejection. `workflow` is exposed on `RailwayIacApplyResponse` so callers can inspect the terminal state. Applies that stage nothing skip the poll entirely, so the no-op path is unchanged.

## 2. Create buckets in the target environment (#60)

`createBucketForResource` hardcoded `environmentId: null`, producing a project-level row with no environment instance: invisible to `railway bucket list`, no credentials, no storage. Because there is **no bucket delete API**, that orphan holds the name forever — so the retry can never create the bucket it was asked for, and the name is burned in that project permanently.

`ensureGraphResources` already receives `environmentId` and threads it to `createServiceForResource` and `createVolumeForService`; the bucket call was the only one dropping it. One-line fix, plus a comment so it does not regress.

## Validation

6 new tests:
- rejected commit workflow → `ok: false` + diagnostic carrying the platform error
- `waitForWorkflow` polls through `Running` → terminal, and reports timeout distinctly (injectable `now`/`sleep`, so no real delays in tests)
- `bucketCreate` receives the environment id
- the existing etag-threading test gains its `workflowStatus` response

`pnpm run typecheck`, `pnpm run test` (212 passed), `pnpm run build` all green.

Both fixes are also running against the live project that surfaced them.
