### PR TITLE
fix: reject interrupted sandbox execs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export {
 } from "./iac/index.js";
 export {
   ExecHandle,
+  ExecInterruptedError,
   Sandbox,
   SandboxFailedError,
   SandboxFileNotFoundError,

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -1,5 +1,28 @@
-import { RailwayError } from "../core/errors.js";
+import { RailwayConnectionError, RailwayError } from "../core/errors.js";
 import type { SandboxStatus } from "./types.js";
+
+/** The socket closed before the command reported an exit, usually because the sandbox was already gone or died mid-exec. */
+export class ExecInterruptedError extends RailwayConnectionError {
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(args: {
+    closeCode: number;
+    reason: string;
+    stdout: string;
+    stderr: string;
+  }) {
+    super({
+      message:
+        `The exec session closed before the command reported an exit ` +
+        `(code ${args.closeCode}${args.reason ? `: ${args.reason}` : ""}). ` +
+        `The command's outcome is unknown; the sandbox may have been destroyed.`,
+      closeCode: args.closeCode,
+    });
+    this.stdout = args.stdout;
+    this.stderr = args.stderr;
+  }
+}
 
 export class SandboxNotFoundError extends RailwayError {
   readonly id: string;

--- a/src/sandbox/exec.ts
+++ b/src/sandbox/exec.ts
@@ -5,6 +5,7 @@ import {
   type ExecWsConnection,
 } from "../core/exec-ws-client.js";
 import { requestGraphQL } from "../core/graphql-client.js";
+import { ExecInterruptedError } from "./errors.js";
 import {
   RailwayGenerateShellTokenDocument,
   type RailwayGenerateShellTokenMutation,
@@ -315,8 +316,20 @@ async function runExec(
         exitCode = code;
         settle({ exitCode, stdout, stderr, truncated: false, timedOut });
       },
-      onClose: () =>
-        settle({ exitCode, stdout, stderr, truncated: false, timedOut }),
+      onClose: info => {
+        if (control.detached || timedOut) {
+          settle({ exitCode, stdout, stderr, truncated: false, timedOut });
+          return;
+        }
+        settle({
+          error: new ExecInterruptedError({
+            closeCode: info.code,
+            reason: info.reason,
+            stdout,
+            stderr,
+          }),
+        });
+      },
     },
   });
   control.connection = connection;

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,6 @@
 export { Sandbox } from "./sandbox.js";
 export {
+  ExecInterruptedError,
   SandboxFailedError,
   SandboxFileNotFoundError,
   SandboxFilesError,

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -271,4 +271,29 @@ describe("exec", () => {
     socket.serverExit(0);
     await expect(handle).resolves.toMatchObject({ exitCode: 0 });
   });
+
+  // A close without an exit frame leaves the command outcome unknown.
+  it("rejects when the socket closes without an exit frame", async () => {
+    const { handle, socket } = await execSocket("echo hi");
+
+    socket.serverClose(1006, "no such instance");
+
+    await expect(handle).rejects.toThrow(
+      /closed before the command reported an exit/i,
+    );
+  });
+
+  it("carries the close code and any partial output on an interrupted exec", async () => {
+    const { handle, socket } = await execSocket("long-running");
+
+    socket.serverStdout("partial\n");
+    await tick();
+    socket.serverClose(1011, "instance gone");
+
+    await expect(handle).rejects.toMatchObject({
+      name: "ExecInterruptedError",
+      closeCode: 1011,
+      stdout: "partial\n",
+    });
+  });
 });


### PR DESCRIPTION
## Summary of changes

`Sandbox.exec()` now rejects with `ExecInterruptedError` when its socket closes before the command reports an exit. Previously, this resolved with `exitCode: null` and empty output, making an interrupted command look successful.

Timeouts and explicit `detach()` calls continue to resolve as documented. The error preserves the close code and any partial stdout or stderr.

Given this feature is still in PB this is a minor release despite being breaking

Review notes:

- `kill()` followed by a socket close without an exit frame now rejects because the command outcome is unknown.
- `sessionName` is not currently included on `ExecInterruptedError`; exposing it for reattachment can be considered separately.

## Docs

`ExecInterruptedError` extends `RailwayConnectionError` and exposes `closeCode`, `stdout`, and `stderr`.