### PR TITLE
Poll asynchronous IaC applies

### DIFF
--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -197,13 +197,36 @@ export class IacClient {
       const data = await gql<{ environmentApplyChangeSet: ChangeSetApplyResult }, typeof variables>(this.#config, `mutation IacApplyChangeSet($environmentId: String!, $input: JSON!, $commitMessage: String, $baseConfigEtag: String) {
         environmentApplyChangeSet(environmentId: $environmentId, input: $input, commitMessage: $commitMessage, baseConfigEtag: $baseConfigEtag) { id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs } }
       }`, variables);
-      return data.environmentApplyChangeSet;
+      if (data.environmentApplyChangeSet.status !== "applying") {
+        return data.environmentApplyChangeSet;
+      }
+      return await this.waitForChangeSetApply({
+        environmentId,
+        id: data.environmentApplyChangeSet.id,
+      });
     } catch (error) {
       if (isStaleBaseError(error)) {
         throw new StaleEnvironmentError("The environment changed since this plan was computed. Re-run plan and review the changes before applying.", { cause: error });
       }
       throw error;
     }
+  }
+
+  async waitForChangeSetApply({ environmentId, id }: { environmentId: string; id: string }): Promise<ChangeSetApplyResult> {
+    const deadline = Date.now() + 2 * 60 * 60 * 1000;
+    while (Date.now() < deadline) {
+      const data = await gql<
+        { environmentChangeSetApply: ChangeSetApplyResult },
+        { environmentId: string; id: string }
+      >(this.#config, `query IacChangeSetApplyStatus($environmentId: String!, $id: String!) {
+        environmentChangeSetApply(environmentId: $environmentId, id: $id) { id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs } }
+      }`, { environmentId, id });
+      if (data.environmentChangeSetApply.status !== "applying") {
+        return data.environmentChangeSetApply;
+      }
+      await new Promise(resolve => setTimeout(resolve, 1_000));
+    }
+    throw new Error(`Timed out waiting for Railway ChangeSet apply ${id}`);
   }
 
   async commitStagedPatch({ environmentId, message, skipDeploys }: { environmentId: string; message?: string; skipDeploys?: boolean }): Promise<string> {

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -43,6 +43,67 @@ describe("IaC apply — configEtag handshake", () => {
     expect(variablesOf(mock.calls[0]).baseConfigEtag).toBeUndefined();
   });
 
+  it("polls asynchronous applies until the durable workflow completes", async () => {
+    vi.useFakeTimers();
+    const mock = createFetchMock([
+      {
+        data: {
+          environmentApplyChangeSet: {
+            ...applyOk.data.environmentApplyChangeSet,
+            id: "iac-change-set/e1/abc",
+            status: "applying",
+            deploymentId: "iac-change-set/e1/abc",
+          },
+        },
+      },
+      {
+        data: {
+          environmentChangeSetApply: {
+            ...applyOk.data.environmentApplyChangeSet,
+            id: "iac-change-set/e1/abc",
+            status: "applying",
+          },
+        },
+      },
+      {
+        data: {
+          environmentChangeSetApply: {
+            ...applyOk.data.environmentApplyChangeSet,
+            id: "iac-change-set/e1/abc",
+          },
+        },
+      },
+    ]);
+
+    const largeChangeSet: RailwayChangeSet = {
+      version: 1,
+      diagnostics: [],
+      changes: Array.from({ length: 500 }, (_, index) => ({
+        kind: "resource.update" as const,
+        address: `service.worker-${index}` as `service.${string}`,
+        field: "deploy.numReplicas",
+        path: `service.worker-${index}.deploy.numReplicas`,
+        summary: `Scale worker-${index}`,
+        severity: "safe" as const,
+        deployEffect: "deploy" as const,
+        before: 1,
+        after: 2,
+      })),
+    };
+    const result = client(mock.fetch).applyChangeSet({
+      environmentId: "e1",
+      changeSet: largeChangeSet,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(result).resolves.toMatchObject({ status: "applied" });
+    expect(mock.calls).toHaveLength(3);
+    expect(
+      (variablesOf(mock.calls[0]).input as RailwayChangeSet).changes,
+    ).toHaveLength(500);
+    vi.useRealTimers();
+  });
+
   it("maps a STALE_ENVIRONMENT_BASE rejection to StaleEnvironmentError", async () => {
     const mock = createFetchMock([
       { errors: [{ message: "stale", extensions: { code: "STALE_ENVIRONMENT_BASE" } }] },


### PR DESCRIPTION
Polls the durable ChangeSet workflow with short GraphQL requests until completion, preserving final apply results while avoiding gateway timeouts; covers 500-change payloads.