### PR TITLE
Apply custom and service domain changes & exclude preserveExisting variables from plan

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -1,6 +1,6 @@
 import { composePatch, graphToEnvironmentConfig } from "./compiler.js";
 import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, ServiceNode, VariableValue, VolumeNode } from "./graph.js";
-import type { EnvironmentConfig } from "./schema.js";
+import type { DomainConfig, EnvironmentConfig, ServiceNetworking } from "./schema.js";
 
 // Wire-contract version for the RailwayChangeSet exchanged with backboard.
 // v1 adds the optional base-config etag handshake on apply (compare-and-swap).
@@ -25,7 +25,9 @@ export type RailwayChange =
   | UpdateResourceChange
   | SetVariableChange
   | DeleteVariableChange
-  | CreateDomainChange;
+  | CreateDomainChange
+  | UpdateDomainChange
+  | DeleteDomainChange;
 
 export interface ChangeBase {
   kind: string;
@@ -72,11 +74,33 @@ export interface DeleteVariableChange extends ChangeBase {
   previous: VariableValue;
 }
 
+// Railway has two kinds of domains, provisioned by different mutations: `service`
+// domains are Railway subdomains (*.up.railway.app), `custom` domains are user-owned.
+// `domainType` tells apply which mutation family to use.
+export type DomainType = "custom" | "service";
+
 export interface CreateDomainChange extends ChangeBase {
   kind: "domain.create";
   address: ResourceAddress;
+  domainType: DomainType;
   domain: string;
   targetPort?: number;
+}
+
+export interface UpdateDomainChange extends ChangeBase {
+  kind: "domain.update";
+  address: ResourceAddress;
+  domainType: DomainType;
+  domain: string;
+  before?: number;
+  targetPort?: number;
+}
+
+export interface DeleteDomainChange extends ChangeBase {
+  kind: "domain.delete";
+  address: ResourceAddress;
+  domainType: DomainType;
+  domain: string;
 }
 
 export interface ChangeDiagnostic {
@@ -102,7 +126,6 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
       continue;
     }
     if (!previous) {
-      diagnoseUnsupportedCustomDomains({ resource, diagnostics });
       changes.push({
         kind: "resource.create",
         address: resource.address,
@@ -112,6 +135,10 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
         severity: "safe",
         deployEffect: resource.type === "service" || resource.type === "database" ? "deploy" : "none",
       });
+
+      const networking = "networking" in resource ? resource.networking : undefined;
+      diffDomains({ resource, domainType: "custom", before: undefined, after: networking?.customDomains, changes });
+      diffDomains({ resource, domainType: "service", before: undefined, after: networking?.serviceDomains, changes });
       continue;
     }
 
@@ -130,7 +157,7 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
       diffTopLevelField({ previous, resource, field: "deploy", changes });
     }
     diffTopLevelField({ previous, resource, field: "groupId", changes });
-    diffNetworking({ previous, resource, changes, diagnostics });
+    diffNetworking({ previous, resource, changes });
     // Volume lifecycle is not part of v0 authoring. Never plan an accidental unmount just
     // because imported config omitted a Railway-owned volume id.
     if (previous.type === "bucket" && resource.type === "bucket" && bucketRegion(previous) !== bucketRegion(resource)) {
@@ -183,6 +210,13 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
   return { version: RAILWAY_CHANGE_SET_VERSION, changes, diagnostics };
 }
 
+function getResourceDomains(resource: ResourceNode, domainType: DomainType): Record<string, DomainConfig | null> | null {
+  const networking = (resource as ServiceNode).networking;
+  return domainType === 'custom'
+    ? networking?.customDomains ?? null
+    : networking?.serviceDomains ?? null
+}
+
 export function changeSetToGraph({ current, changeSet }: { current: RailwayGraph; changeSet: RailwayChangeSet }): RailwayGraph {
   const next = structuredClone(current) as RailwayGraph;
   const resources = new Map<ResourceAddress, ResourceNode>(next.resources.map(resource => [resource.address, resource]));
@@ -202,6 +236,40 @@ export function changeSetToGraph({ current, changeSet }: { current: RailwayGraph
     if (!resource) continue;
 
     if (change.kind === "domain.create") {
+      let networking = (resource as ServiceNode).networking;
+      if (!networking) {
+        networking = (resource as ServiceNode).networking = {};
+      }
+
+      if (change.domainType === "custom") {
+        if (!networking.customDomains) networking.customDomains = {};
+        networking.customDomains[change.domain] = change.targetPort != null ? { port: change.targetPort } : {};
+      } else {
+        if (!networking.serviceDomains) networking.serviceDomains = {};
+        networking.serviceDomains[change.domain] = change.targetPort != null ? { port: change.targetPort } : {};
+      }
+    }
+
+    if (change.kind === "domain.update") {
+      let networking = (resource as ServiceNode).networking;
+      if (!networking) {
+        networking = (resource as ServiceNode).networking = {};
+      }
+
+      if (change.domainType === "custom") {
+        if (!networking.customDomains) networking.customDomains = {};
+        networking.customDomains[change.domain] = change.targetPort != null ? { port: change.targetPort } : {};
+      } else {
+        if (!networking.serviceDomains) networking.serviceDomains = {};
+        networking.serviceDomains[change.domain] = change.targetPort != null ? { port: change.targetPort } : {};
+      }
+      continue;
+    }
+
+    if (change.kind === "domain.delete") {
+      const networking = (resource as ResourceNode & { networking?: ServiceNetworking }).networking;
+      const domains = change.domainType === 'custom' ? networking?.customDomains : networking?.serviceDomains;
+      delete domains?.[change.domain];
       continue;
     }
 
@@ -300,35 +368,78 @@ function diffVariables({ previous, resource, changes, resourcesByAddress, reveal
   }
 }
 
-function diffNetworking({ previous, resource, changes, diagnostics }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[]; diagnostics: ChangeDiagnostic[] }) {
+function diffNetworking({ previous, resource, changes }: { previous: ResourceNode; resource: ResourceNode; changes: RailwayChange[] }) {
   const before = "networking" in previous ? previous.networking : undefined;
   const after = "networking" in resource ? resource.networking : undefined;
-  const beforeDomains = before?.customDomains ?? {};
-  diagnoseUnsupportedCustomDomains({ resource, diagnostics, existingDomains: beforeDomains });
 
   const normalizedBefore = normalizeForDiff("networking", { ...before, customDomains: undefined, serviceDomains: undefined });
   const normalizedAfter = normalizeForDiff("networking", { ...after, customDomains: undefined, serviceDomains: undefined });
   if (stableStringify(normalizedBefore) !== stableStringify(normalizedAfter)) {
     changes.push(update(resource.address, "networking", normalizedBefore, normalizedAfter, `Update ${resource.name} networking`));
   }
+
+  diffDomains({ resource, domainType: "custom", before: before?.customDomains, after: after?.customDomains, changes });
+  diffDomains({ resource, domainType: "service", before: before?.serviceDomains, after: after?.serviceDomains, changes });
 }
 
-function diagnoseUnsupportedCustomDomains({
-  resource,
-  diagnostics,
-  existingDomains = {},
-}: {
+// Diffs one domain map (custom or service) into per-domain create/update/delete changes.
+// Backboard applies each via the matching mutation family (see DomainType).
+function diffDomains({ resource, domainType, before, after, changes }: {
   resource: ResourceNode;
-  diagnostics: ChangeDiagnostic[];
-  existingDomains?: Record<string, unknown>;
+  domainType: DomainType;
+  before: Record<string, DomainConfig | null> | null | undefined;
+  after: Record<string, DomainConfig | null> | null | undefined;
+  changes: RailwayChange[];
 }) {
-  const desiredDomains = ("networking" in resource ? resource.networking : undefined)?.customDomains ?? {};
-  for (const domain of Object.keys(desiredDomains)) {
-    if (existingDomains[domain]) continue;
-    diagnostics.push({
-      severity: "error",
+  const beforeDomains = (normalizeForDiff('networking', before) ?? {}) as Record<string, DomainConfig | null>
+  const afterDomains = (normalizeForDiff('networking', after) ?? {}) as Record<string, DomainConfig | null>
+  const label = domainType === "custom" ? "custom domain" : "service domain";
+
+  for (const [domain, beforeConfig] of Object.entries(beforeDomains)) {
+    if (beforeConfig == null) continue;
+    if (!(domain in afterDomains) || afterDomains[domain] == null) {
+      changes.push({
+        kind: "domain.delete",
+        address: resource.address,
+        domainType,
+        domain,
+        path: `resources.${resource.address}.domains.${domain}`,
+        summary: `Delete ${label} ${resource.name}.${domain}`,
+        severity: "destructive",
+        deployEffect: "none",
+      });
+      continue;
+    }
+    const beforePort = beforeConfig.port ?? 8080;
+    const afterPort = afterDomains[domain]?.port ?? 8080;
+    if (beforePort === afterPort) continue;
+    changes.push({
+      kind: "domain.update",
+      address: resource.address,
+      domainType,
+      domain,
+      before: beforePort,
+      targetPort: afterPort,
       path: `resources.${resource.address}.domains.${domain}`,
-      message: `Custom-domain registration is not supported by Railway configuration. Add ${domain} in the dashboard, then run railway config pull.`,
+      summary: `Update ${label} ${resource.name}.${domain} target port ${beforePort} → ${afterPort}`,
+      severity: "safe",
+      deployEffect: "none",
+    });
+  }
+
+  for (const [domain, afterConfig] of Object.entries(afterDomains)) {
+    if (afterConfig == null) continue;
+    if (domain in beforeDomains && beforeDomains[domain] != null) continue;
+    changes.push({
+      kind: "domain.create",
+      address: resource.address,
+      domainType,
+      domain,
+      ...(afterConfig.port != null ? { targetPort: afterConfig.port } : {}),
+      path: `resources.${resource.address}.domains.${domain}`,
+      summary: `Create ${label} ${resource.name}.${domain}`,
+      severity: "safe",
+      deployEffect: "none",
     });
   }
 }
@@ -616,7 +727,7 @@ function update(address: ResourceAddress, field: string, before: unknown, after:
 
 function marker(change: RailwayChange): string {
   if (change.kind === "resource.create" || change.kind === "domain.create") return "+";
-  if (change.kind === "resource.delete") return "-";
+  if (change.kind === "resource.delete" || change.kind === "domain.delete") return "-";
   return "~";
 }
 
@@ -712,6 +823,25 @@ function normalizeForDiff(field: string, value: unknown): unknown {
     // The assignment above can leave the key holding undefined, making an
     // otherwise-empty deploy compare unequal to an absent one
     if (copy.multiRegionConfig === undefined) delete copy.multiRegionConfig;
+  }
+
+  if (field === "networking") {
+    // Domains stay in the networking config; give every domain an explicit port so a
+    // Railway-reported `{}` (no targetPort) and an authored `{port:8080}` compare equal and
+    // a round-tripped domain doesn't churn a networking update every apply.
+    for (const key of ["customDomains", "serviceDomains"] as const) {
+      const domains = copy[key] as Record<string, { port?: number } | null> | undefined;
+      if (domains == null || typeof domains !== "object" || Array.isArray(domains)) {
+        delete copy[key];
+        continue;
+      }
+      for (const [domainName, domainConfig] of Object.entries(domains)) {
+        domains[domainName] = {
+          ...(domainConfig || {}),
+          port: domainConfig?.port ?? 8080
+        }
+      }
+    }
   }
 
   return Object.keys(copy).length === 0 ? undefined : copy;

--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -673,7 +673,9 @@ function isEquivalentDatabaseSource(previous: ResourceNode, after: unknown): boo
 }
 
 function isPreservedVariable(value: VariableValue | undefined): boolean {
-  return value?.type === "preserve";
+  return value?.type === "preserve" ||
+    (value?.type === 'literal' && !!value.preserveExisting) ||
+    (value?.type === 'raw' && !!value.value.preserveExisting);
 }
 
 function isUnknownCurrentVariable(value: VariableValue | undefined): boolean {

--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -3,8 +3,8 @@ import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { normalizeRailwayClientConfig, type RailwayClientConfig, type NormalizedRailwayClientConfig } from "../core/config.js";
 import { requestGraphQL } from "../core/graphql-client.js";
 import { RailwayGraphQLError, StaleEnvironmentError, STALE_ENVIRONMENT_BASE_CODE } from "../core/errors.js";
-import type { BucketCreateInput, ServiceCreateInput, VolumeCreateInput } from "../generated/graphql.js";
-import type { RailwayChangeSet } from "./change-set.js";
+import type { BucketCreateInput, CustomDomainCreateInput, ServiceCreateInput, ServiceDomainCreateInput, ServiceDomainUpdateInput, VolumeCreateInput } from "../generated/graphql.js";
+import type { CreateDomainChange, DeleteDomainChange, DomainType, RailwayChange, RailwayChangeSet, UpdateDomainChange } from "./change-set.js";
 import type { RailwayGraph, ResourceNode } from "./graph.js";
 import type { EnvironmentConfig } from "./schema.js";
 
@@ -54,6 +54,17 @@ export interface ChangeSetApplyResult {
   stagedPatchId?: string | null;
 }
 
+export interface DomainRecord { id: string; domain: string; port?: number }
+interface RawDomain { id: string; domain: string; targetPort?: number | null }
+
+export interface DomainReconcileResult {
+  kind: "domain.create" | "domain.update" | "domain.delete";
+  domainType: DomainType;
+  address: string;
+  domain: string;
+  status: "created" | "updated" | "deleted" | "skipped" | "failed";
+  reason?: string;
+}
 export interface ProjectService { id: string; name: string }
 export interface ProjectVolume { id: string; name?: string | null; serviceId?: string | null }
 export interface ProjectBucket { id: string; name: string; groupId?: string | null }
@@ -145,6 +156,57 @@ export class IacClient {
       return [service.id, Object.fromEntries(data.domains.customDomains.map(domain => [domain.domain, domain.targetPort == null ? {} : { port: domain.targetPort }]))] as const;
     }));
     return Object.fromEntries(entries.filter(([, domains]) => Object.keys(domains).length > 0));
+  }
+
+  // Fetches existing domains (custom + service) with their ids — needed to update/delete a
+  // domain, which the dedicated mutations key by id rather than by name.
+  async getServiceDomainRecords(projectId: string, environmentId: string, serviceId: string): Promise<{ custom: DomainRecord[]; service: DomainRecord[] }> {
+    const data = await gql<{ domains: { customDomains: RawDomain[]; serviceDomains: RawDomain[] } }, { projectId: string; environmentId: string; serviceId: string }>(this.#config, `query IacServiceDomainRecords($projectId: String!, $environmentId: String!, $serviceId: String!) {
+      domains(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId) {
+        customDomains { id domain targetPort }
+        serviceDomains { id domain targetPort }
+      }
+    }`, { projectId, environmentId, serviceId });
+    const map = (list: RawDomain[]): DomainRecord[] => list.map(domain => ({ id: domain.id, domain: domain.domain, ...(domain.targetPort == null ? {} : { port: domain.targetPort }) }));
+    return { custom: map(data.domains.customDomains), service: map(data.domains.serviceDomains) };
+  }
+
+  async createCustomDomain(input: CustomDomainCreateInput): Promise<DomainRecord> {
+    const data = await gql<{ customDomainCreate: { id: string; domain: string } }, { input: CustomDomainCreateInput }>(this.#config, `mutation IacCustomDomainCreate($input: CustomDomainCreateInput!) {
+      customDomainCreate(input: $input) { id domain }
+    }`, { input });
+    return data.customDomainCreate;
+  }
+
+  async updateCustomDomain(args: { environmentId: string; id: string; targetPort?: number }): Promise<void> {
+    await gql<{ customDomainUpdate: boolean }, { environmentId: string; id: string; targetPort?: number }>(this.#config, `mutation IacCustomDomainUpdate($environmentId: String!, $id: String!, $targetPort: Int) {
+      customDomainUpdate(environmentId: $environmentId, id: $id, targetPort: $targetPort)
+    }`, args);
+  }
+
+  async deleteCustomDomain(id: string): Promise<void> {
+    await gql<{ customDomainDelete: boolean }, { id: string }>(this.#config, `mutation IacCustomDomainDelete($id: String!) {
+      customDomainDelete(id: $id)
+    }`, { id });
+  }
+
+  async createServiceDomain(input: ServiceDomainCreateInput): Promise<DomainRecord> {
+    const data = await gql<{ serviceDomainCreate: { id: string; domain: string } }, { input: ServiceDomainCreateInput }>(this.#config, `mutation IacServiceDomainCreate($input: ServiceDomainCreateInput!) {
+      serviceDomainCreate(input: $input) { id domain }
+    }`, { input });
+    return data.serviceDomainCreate;
+  }
+
+  async updateServiceDomain(input: ServiceDomainUpdateInput): Promise<void> {
+    await gql<{ serviceDomainUpdate: boolean }, { input: ServiceDomainUpdateInput }>(this.#config, `mutation IacServiceDomainUpdate($input: ServiceDomainUpdateInput!) {
+      serviceDomainUpdate(input: $input)
+    }`, { input });
+  }
+
+  async deleteServiceDomain(id: string): Promise<void> {
+    await gql<{ serviceDomainDelete: boolean }, { id: string }>(this.#config, `mutation IacServiceDomainDelete($id: String!) {
+      serviceDomainDelete(id: $id)
+    }`, { id });
   }
 
   async ensureGraphResources({ projectId, environmentId, graph, currentConfig }: {
@@ -265,6 +327,65 @@ export class IacClient {
       serviceCreate(input: $input) { id name }
     }`, { input });
     return data.serviceCreate;
+  }
+
+  // Realizes the plan's domain.* changes through the dedicated domain mutations, which are
+  // the only mechanism that actually provisions domains (the config/change-set path does
+  // not). Runs after applyChangeSet so services created by the change set already exist.
+  async reconcileDomains({ projectId, environmentId, changes }: { projectId: string; environmentId: string; changes: RailwayChange[] }): Promise<DomainReconcileResult[]> {
+    const domainChanges = changes.filter((change): change is CreateDomainChange | UpdateDomainChange | DeleteDomainChange =>
+      change.kind === "domain.create" || change.kind === "domain.update" || change.kind === "domain.delete");
+    if (domainChanges.length === 0) return [];
+
+    // Resolve service ids from the post-apply project state (a change set may have just
+    // created the target service).
+    const services = await this.getProjectServices(projectId);
+    const serviceIdByName = Object.fromEntries(services.map(service => [service.name, service.id]));
+    const recordsCache = new Map<string, { custom: DomainRecord[]; service: DomainRecord[] }>();
+    const findDomainId = async (serviceId: string, domainType: DomainType, domain: string): Promise<string | undefined> => {
+      let records = recordsCache.get(serviceId);
+      if (!records) { records = await this.getServiceDomainRecords(projectId, environmentId, serviceId); recordsCache.set(serviceId, records); }
+      return (domainType === "custom" ? records.custom : records.service).find(record => record.domain === domain)?.id;
+    };
+
+    const results: DomainReconcileResult[] = [];
+    for (const change of domainChanges) {
+      const serviceName = change.address.slice("service.".length);
+      const serviceId = serviceIdByName[serviceName];
+      const base = { kind: change.kind, domainType: change.domainType, address: change.address, domain: change.domain } as const;
+      if (!serviceId) { results.push({ ...base, status: "skipped", reason: `service ${serviceName} not found` }); continue; }
+      const targetPort = "targetPort" in change && change.targetPort != null ? { targetPort: change.targetPort } : {};
+      try {
+        if (change.kind === "domain.create") {
+          if (change.domainType === "custom") {
+            await this.createCustomDomain({ domain: change.domain, environmentId, projectId, serviceId, ...targetPort });
+          } else {
+            // serviceDomainCreate assigns a random *.up.railway.app subdomain; immediately
+            // rename it to the authored name so the result is deterministic and re-diffs clean.
+            const created = await this.createServiceDomain({ environmentId, serviceId, ...targetPort });
+            if (created.domain !== change.domain) {
+              await this.updateServiceDomain({ environmentId, serviceId, serviceDomainId: created.id, domain: change.domain, ...targetPort });
+            }
+          }
+          results.push({ ...base, status: "created" });
+        } else if (change.kind === "domain.update") {
+          const id = await findDomainId(serviceId, change.domainType, change.domain);
+          if (!id) { results.push({ ...base, status: "skipped", reason: "existing domain not found" }); continue; }
+          if (change.domainType === "custom") await this.updateCustomDomain({ environmentId, id, ...targetPort });
+          else await this.updateServiceDomain({ environmentId, serviceId, serviceDomainId: id, domain: change.domain, ...targetPort });
+          results.push({ ...base, status: "updated" });
+        } else {
+          const id = await findDomainId(serviceId, change.domainType, change.domain);
+          if (!id) { results.push({ ...base, status: "skipped", reason: "existing domain not found" }); continue; }
+          if (change.domainType === "custom") await this.deleteCustomDomain(id);
+          else await this.deleteServiceDomain(id);
+          results.push({ ...base, status: "deleted" });
+        }
+      } catch (error) {
+        results.push({ ...base, status: "failed", reason: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    return results;
   }
 }
 

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -1,6 +1,6 @@
-import { diffGraphs, renderChangeSet, type RailwayChangeSet } from "./change-set.js";
+import { diffGraphs, RailwayChange, renderChangeSet, type RailwayChangeSet } from "./change-set.js";
 import { environmentConfigToGraph } from "./compiler.js";
-import { IacClient, type ChangeSetApplyResult, type ChangeSetPreviewResult, type CurrentEnvironmentResult } from "./client.js";
+import { IacClient, type ChangeSetApplyResult, type ChangeSetPreviewResult, type CurrentEnvironmentResult, type DomainReconcileResult } from "./client.js";
 import { validateGraph, type RailwayGraph } from "./graph.js";
 import { evaluateRailwayProject, findRailwayFile } from "./project.js";
 import { renderRailwayGraphTypes } from "./typegen.js";
@@ -89,6 +89,7 @@ export interface RailwayIacStageResponse extends Omit<RailwayIacPlanResponse, "c
 export interface RailwayIacApplyResponse extends Omit<RailwayIacStageResponse, "command"> {
   command: "apply";
   applyResult?: ChangeSetApplyResult;
+  domainResults?: DomainReconcileResult[];
   deploymentId?: string;
   stagedPatchId?: string;
 }
@@ -231,20 +232,43 @@ async function applyRailwayIac(input: EvaluatedCommandInput): Promise<RailwayIac
     return { ...planned, command: "apply" };
   }
 
+  const domainChanges: RailwayChange[] = [];
+  const restChanges: RailwayChange[] = [];
+
+  for (const change of planned.changeSet.changes) {
+    if (change.kind.startsWith('domain.*')) {
+      domainChanges.push(change);
+    } else {
+      restChanges.push(change);
+    }
+  }
+
   const context = requireBackboardContext(input.request.backboard, "apply");
   const client = new IacClient(clientConfig(context));
   const applyResult = await client.applyChangeSet({
     environmentId: context.environmentId,
-    changeSet: planned.changeSet,
+    changeSet: {
+      ...planned.changeSet,
+      changes: restChanges,
+    },
     commitMessage: "Apply Railway configuration",
     // Base snapshot the plan was diffed against; backboard rejects a stale apply.
     ...(planned.currentEnvironment?.configEtag ? { baseEtag: planned.currentEnvironment.configEtag } : {}),
   });
 
+  // Realize the plan's domain.* changes via the dedicated domain mutations after the change
+  // set has created/updated any referenced services.
+  const projectId = planned.currentEnvironment?.projectId;
+  const domainResults = projectId && domainChanges.length
+    ? await client.reconcileDomains({ projectId, environmentId: context.environmentId, changes: domainChanges })
+    : [];
+
   return {
     ...planned,
+    ok: planned.ok && !domainResults.some(v => v.status === 'failed'),
     command: "apply",
     applyResult,
+    ...(domainResults.length > 0 ? { domainResults } : {}),
     ...(applyResult.deploymentId ? { deploymentId: applyResult.deploymentId } : {}),
     ...(applyResult.stagedPatchId ? { stagedPatchId: applyResult.stagedPatchId } : {}),
   };

--- a/src/iac/sdk.ts
+++ b/src/iac/sdk.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { resourceAddress } from "./graph.js";
 import type {
   BucketNode,
   DatabaseNode,
@@ -7,17 +6,18 @@ import type {
   GroupableResourceInput,
   GroupableResourceNode,
   ProjectDefinition,
-  ProjectResourceInput,
   ResourceNode,
   ServiceNode,
   SourceConfig,
   VariableValue,
-  VolumeNode,
+  VolumeNode
 } from "./graph.js";
+import { resourceAddress } from "./graph.js";
 import type {
   BucketConfig,
   BuildConfig,
   DeployConfig,
+  DomainConfig,
   ServiceConfig,
   ServiceNetworking,
   VariableConfig,
@@ -339,15 +339,43 @@ function normalizeRegions(regions: Record<string, RegionConfig>): NonNullable<De
 }
 
 function normalizeNetworking(config: ServiceConfigInput): ServiceNetworking | undefined {
-  const customDomains = config.domains
-    ? Object.fromEntries(config.domains.map(domain => (typeof domain === "string" ? [domain, { port: 8080 }] : [domain.domain, { port: domain.port ?? 8080 }])))
-    : undefined;
+  const customDomains: Record<string, DomainConfig | null> = config.networking?.customDomains
+    ? structuredClone(config.networking?.customDomains)
+    : {};
+  const serviceDomains: Record<string, DomainConfig | null> = config.networking?.serviceDomains
+    ? structuredClone(config.networking?.serviceDomains)
+    : {};
+
+  for (const domain of (config.domains ?? [])) {
+    let targetPort = 8080;
+    let targetDomain = "";
+    if (typeof domain === "string") {
+      targetDomain = domain.trim();
+    } else {
+      targetDomain = domain.domain?.trim();
+      targetPort = domain.port ?? targetPort;
+    }
+
+    if (!targetDomain) continue;
+    if (isServiceDomain(targetDomain)) {
+      serviceDomains[targetDomain] = { port: targetPort };
+    } else {
+      customDomains[targetDomain] = { port: targetPort };
+    }
+  }
+
   const tcpProxies = config.tcp
     ? Object.fromEntries(config.tcp.map(port => [String(port), {}]))
     : config.tcpProxies
       ? Object.fromEntries(config.tcpProxies.map(port => [port, {}]))
       : undefined;
-  return pruneEmpty({ ...config.networking, customDomains, tcpProxies }) as ServiceNetworking | undefined;
+
+  return pruneEmpty({
+    ...config.networking,
+    customDomains: Object.keys(customDomains).length ? customDomains : undefined,
+    serviceDomains: Object.keys(serviceDomains).length ? serviceDomains : undefined,
+    tcpProxies
+  }) as ServiceNetworking | undefined;
 }
 
 function normalizeVariables(variables: Record<string, string | VariableConfig | VariableValue>): Record<string, VariableValue> {
@@ -383,4 +411,8 @@ function pruneEmpty<T>(value: T): T | undefined {
   const entries = Object.entries(value).filter(([, child]) => child != null);
   if (entries.length === 0) return undefined;
   return Object.fromEntries(entries) as T;
+}
+
+function isServiceDomain(value: string): boolean {
+  return value.endsWith('.up.railway.app')
 }

--- a/tests/iac-apply.test.ts
+++ b/tests/iac-apply.test.ts
@@ -78,6 +78,71 @@ describe("IaC apply — configEtag handshake", () => {
   });
 });
 
+describe("IaC apply — reconcileDomains dispatches dedicated domain mutations", () => {
+  const domainChange = (kind: "domain.create" | "domain.update" | "domain.delete", extra: Record<string, unknown>) =>
+    ({ kind, address: "service.web", domainType: "custom", domain: "app.example.com", path: "", summary: "", severity: "safe", deployEffect: "none", ...extra }) as RailwayChangeSet["changes"][number];
+
+  it("creates, updates, and deletes custom domains with correctly resolved ids and ports", async () => {
+    const mock = createFetchMock([
+      { data: { project: { services: { edges: [{ node: { id: "svc1", name: "web" } }] } } } }, // getProjectServices
+      { data: { customDomainCreate: { id: "d1", domain: "app.example.com" } } },                 // create
+      { data: { domains: { customDomains: [{ id: "d1", domain: "app.example.com", targetPort: 8080 }], serviceDomains: [] } } }, // records (cached after)
+      { data: { customDomainUpdate: true } },                                                     // update
+      { data: { customDomainDelete: true } },                                                     // delete (id from cache)
+    ]);
+
+    const results = await client(mock.fetch).reconcileDomains({
+      projectId: "p1",
+      environmentId: "e1",
+      changes: [
+        domainChange("domain.create", { targetPort: 8080 }),
+        domainChange("domain.update", { before: 8080, targetPort: 3000 }),
+        domainChange("domain.delete", { severity: "destructive" }),
+      ],
+    });
+
+    expect(results.map(result => result.status)).toEqual(["created", "updated", "deleted"]);
+    expect(variablesOf(mock.calls[1]).input).toMatchObject({ domain: "app.example.com", environmentId: "e1", projectId: "p1", serviceId: "svc1", targetPort: 8080 });
+    expect(variablesOf(mock.calls[3])).toMatchObject({ environmentId: "e1", id: "d1", targetPort: 3000 });
+    expect(variablesOf(mock.calls[4])).toMatchObject({ id: "d1" });
+    // records fetched once (cached across update+delete on the same service)
+    expect(mock.calls.length).toBe(5);
+  });
+
+  it("creates a service domain then renames it to the authored name", async () => {
+    const mock = createFetchMock([
+      { data: { project: { services: { edges: [{ node: { id: "svc1", name: "web" } }] } } } },     // getProjectServices
+      { data: { serviceDomainCreate: { id: "sd1", domain: "random-generated.up.railway.app" } } }, // create (random name)
+      { data: { serviceDomainUpdate: true } },                                                       // rename to authored
+    ]);
+
+    const results = await client(mock.fetch).reconcileDomains({
+      projectId: "p1",
+      environmentId: "e1",
+      changes: [{ kind: "domain.create", address: "service.web", domainType: "service", domain: "app-web.up.railway.app", path: "", summary: "", severity: "safe", deployEffect: "none", targetPort: 8080 } as RailwayChangeSet["changes"][number]],
+    });
+
+    expect(results[0]).toMatchObject({ status: "created" });
+    expect(variablesOf(mock.calls[1]).input).toMatchObject({ environmentId: "e1", serviceId: "svc1", targetPort: 8080 });
+    expect(variablesOf(mock.calls[2]).input).toMatchObject({ environmentId: "e1", serviceId: "svc1", serviceDomainId: "sd1", domain: "app-web.up.railway.app", targetPort: 8080 });
+  });
+
+  it("skips a domain change when its service is not found", async () => {
+    const mock = createFetchMock([
+      { data: { project: { services: { edges: [] } } } },
+    ]);
+
+    const results = await client(mock.fetch).reconcileDomains({
+      projectId: "p1",
+      environmentId: "e1",
+      changes: [domainChange("domain.create", { targetPort: 8080 })],
+    });
+
+    expect(results[0]).toMatchObject({ status: "skipped" });
+    expect(mock.calls.length).toBe(1); // no mutation attempted
+  });
+});
+
 describe("IaC runner — threads configEtag from plan into apply", () => {
   afterEach(() => vi.unstubAllGlobals());
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -438,6 +438,24 @@ describe("Railway IaC", () => {
     expect(varChanges).toEqual([]);
   });
 
+  it("never plans a change for a preserveExisting variable, even when the authored value differs", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "r" }, variables: { SECRET: { value: "existing" } } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", {
+        source: github("r"),
+        env: {
+          SECRET: { value: "different", preserveExisting: true },
+          TOKEN: { type: "literal", value: "changed", preserveExisting: true },
+        },
+      })],
+    }));
+
+    const varChanges = diffGraphs({ current, desired }).changes.filter(change => change.kind.startsWith("variable"));
+    expect(varChanges).toEqual([]);
+  });
+
   it("redacts variable values in plan output but keeps them in the change", () => {
     const SECRET = "sk-super-secret-value-123";
     const current = environmentConfigToGraph({ services: { web: { source: { repo: "r" } } } }, { projectName: "app" });

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -3,11 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, group, image, postgres, project, redis, service, volume } from "../src/index.js";
+import { changeSetToEnvironmentPatch, changeSetToGraph, RAILWAY_CHANGE_SET_VERSION, renderChangeSet, SUPPORTED_CHANGE_SET_VERSIONS, type SetVariableChange } from "../src/iac/change-set.js";
 import { projectDefinitionToGraph } from "../src/iac/compiler.js";
-import { changeSetToEnvironmentPatch, RAILWAY_CHANGE_SET_VERSION, SUPPORTED_CHANGE_SET_VERSIONS, renderChangeSet, type SetVariableChange } from "../src/iac/change-set.js";
 import { runRailwayIac } from "../src/iac/runner.js";
 import { preserve } from "../src/iac/sdk.js";
+import { bucket, createRailwayContext, diffGraphs, environmentConfigToGraph, evaluateRailwayFile, github, graphToEnvironmentConfig, group, image, postgres, project, redis, service, volume } from "../src/index.js";
 
 describe("Railway IaC", () => {
   it("emits the current change-set wire version", () => {
@@ -215,19 +215,55 @@ describe("Railway IaC", () => {
     }));
   });
 
-  it("diagnoses unsupported custom-domain registration", () => {
+  it("plans a domain.create for a custom domain on a brand-new service", () => {
     const current = environmentConfigToGraph({ services: {} }, { projectName: "app" });
     const desired = projectDefinitionToGraph(project("app", {
       resources: [service("web", { domains: ["app.example.com"] })],
     }));
 
     const result = diffGraphs({ current, desired });
-    expect(result.changes).not.toContainEqual(expect.objectContaining({ kind: "domain.create" }));
-    expect(result.diagnostics).toContainEqual(expect.objectContaining({
-      severity: "error",
-      path: "resources.service.web.domains.app.example.com",
-      message: expect.stringContaining("not supported"),
+    expect(result.diagnostics).toEqual([]);
+    expect(result.changes).toContainEqual(expect.objectContaining({
+      kind: "domain.create",
+      domainType: "custom",
+      address: "service.web",
+      domain: "app.example.com",
+      targetPort: 8080,
+      severity: "safe",
     }));
+  });
+
+  it("plans a domain.create for a custom domain added to an existing service", () => {
+    const current = environmentConfigToGraph({ services: { web: {} } }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: ["app.example.com"] })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({ current, desired });
+    expect(diagnostics).toEqual([]);
+    expect(changes).toContainEqual(expect.objectContaining({
+      kind: "domain.create",
+      domainType: "custom",
+      domain: "app.example.com",
+    }));
+  });
+
+  it("plans create/update/delete for service domains", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: { networking: { serviceDomains: { "keep-web.up.railway.app": {}, "drop-web.up.railway.app": { port: 3000 } } } } } },
+      { projectName: "app" },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { networking: { serviceDomains: { "keep-web.up.railway.app": {}, "new-web.up.railway.app": { port: 9000 } } } })],
+    }));
+
+    const kinds = diffGraphs({ current, desired }).changes.filter(change => change.kind.startsWith("domain"));
+    expect(kinds).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "domain.create", domainType: "service", domain: "new-web.up.railway.app", targetPort: 9000 }),
+      expect.objectContaining({ kind: "domain.delete", domainType: "service", domain: "drop-web.up.railway.app" }),
+    ]));
+    // keep-web is unchanged (both unset → default port); no update churned.
+    expect(kinds).not.toContainEqual(expect.objectContaining({ domain: "keep-web.up.railway.app" }));
   });
 
   it("keeps existing custom domains plan-clean", () => {
@@ -243,6 +279,113 @@ describe("Railway IaC", () => {
     }));
 
     expect(diffGraphs({ current, desired })).toMatchObject({ changes: [], diagnostics: [] });
+  });
+
+  it("plans a domain.update when an existing custom domain's target port changes", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: {} } },
+      { projectName: "app", customDomainsByServiceId: { web: { "app.example.com": { port: 3000 } } } },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: [{ domain: "app.example.com", port: 8080 }] })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({ current, desired });
+    expect(changes).toContainEqual(expect.objectContaining({
+      kind: "domain.update",
+      domainType: "custom",
+      address: "service.web",
+      domain: "app.example.com",
+      before: 3000,
+      targetPort: 8080,
+      severity: "safe",
+    }));
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("plans a domain.delete when a custom domain is removed from config", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: {} } },
+      { projectName: "app", customDomainsByServiceId: { web: { "app.example.com": {} } } },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", {})],
+    }));
+
+    expect(diffGraphs({ current, desired }).changes).toContainEqual(expect.objectContaining({
+      kind: "domain.delete",
+      domainType: "custom",
+      address: "service.web",
+      domain: "app.example.com",
+      severity: "destructive",
+    }));
+  });
+
+  it("carries domains in the graph for a clean re-diff", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: {} } },
+      { projectName: "app", customDomainsByServiceId: { web: { "keep.example.com": { port: 3000 }, "drop.example.com": {} } } },
+    );
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: [{ domain: "keep.example.com", port: 8080 }] })],
+    }));
+
+    const changeSet = diffGraphs({ current, desired });
+    expect(changeSet.changes.map(change => change.kind).sort()).toEqual(["domain.delete", "domain.update"]);
+
+    const applied = changeSetToGraph({ current, changeSet });
+    expect(diffGraphs({ current: applied, desired }).changes).toEqual([]);
+  });
+
+  it("strips a domain-only networking update from the apply change set but keeps real setting changes", () => {
+    const current = environmentConfigToGraph(
+      { services: { web: {} } },
+      { projectName: "app", customDomainsByServiceId: { web: { "app.example.com": { port: 3000 } } } },
+    );
+    const domainOnly = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: [{ domain: "app.example.com", port: 8080 }] })],
+    }));
+    const networkChanged = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: [{ domain: "app.example.com", port: 3000 }], tcp: [5432] })],
+    }));
+
+    // domain-only: the plan carries a domain.update + a networking update (domains live in the
+    // graph), but the apply change set is emptied — domains are reconciled out-of-band.
+    const domainOnlyChangeSet = diffGraphs({ current, desired: domainOnly });
+    expect(domainOnlyChangeSet.changes.map(change => change.kind).sort()).toEqual(["domain.update"]);
+
+    // a real networking field (tcp) survives stripping, with no domain data in the payload
+    const applyChanges = diffGraphs({ current, desired: networkChanged }).changes;
+    const networking = applyChanges.find(change => change.kind === "resource.update");
+    expect(networking).toMatchObject({ field: "networking", after: { tcpProxies: { "5432": {} } } });
+    expect((networking as { after?: Record<string, unknown> }).after).not.toHaveProperty("customDomains");
+  });
+
+  it("strips domains from a new service's resource.create before apply", () => {
+    const current = environmentConfigToGraph({ services: {} }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { domains: ["app.example.com"], tcp: [5432] })],
+    }));
+
+    const changeSet = diffGraphs({ current, desired });
+    const created = changeSet.changes.find(change => change.kind === "resource.create");
+
+    expect(created?.resource).toStrictEqual({
+      address: "service.web",
+      kind: "empty",
+      name: "web",
+      networking: {
+        customDomains: {
+          "app.example.com": {
+            port: 8080,
+          },
+        },
+        tcpProxies: {
+          "5432": {},
+        },
+      },
+      type: "service",
+    });
   });
 
   it("typechecks known bucket regions", () => {


### PR DESCRIPTION
  Two IaC change-set improvements:

 - **Domains are now applyable**. railway config apply can create, update, and delete both custom domains
  and Railway service domains (*.up.railway.app)
  
 - **preserveExisting variables no longer churn the plan**. Variables marked to preserve their existing
  value are excluded from the diff instead of being planned as changes.
  
Empirical testing against backboard established that `environmentApplyChangeSet` cannot provision 
  domains it silently no-ops domain intent and ignores customDomains/serviceDomains inside a
  networking update (returns applied but creates nothing). The dedicated customDomain / serviceDomain
  mutations do provision them.

So domains are modeled in the plan/graph for a clean diff, but realized through the dedicated mutations at apply time.