### PR TITLE
Enable label-driven SDK releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,33 +6,33 @@ on:
     branches: [main]
 
 concurrency:
-  group: auto-release
+  group: release-bump
   cancel-in-progress: false
 
 permissions:
   actions: read
   checks: read
-  contents: read
+  contents: write
+  id-token: write
   pull-requests: read
 
 jobs:
   auto-release:
     name: Auto Release
-    # Temporarily disabled while releases are paused.
     if: |
-      false &&
       github.event.pull_request.merged == true &&
       (contains(github.event.pull_request.labels.*.name, 'release/patch') ||
        contains(github.event.pull_request.labels.*.name, 'release/minor') ||
        contains(github.event.pull_request.labels.*.name, 'release/major'))
     runs-on: ubuntu-latest
+    outputs:
+      tag: v${{ steps.bump.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Wait for batch window
         run: sleep 120
@@ -47,50 +47,28 @@ jobs:
           echo "Main SHA: $MAIN_SHA"
 
           for i in {1..20}; do
-            CHECKS=$(gh api repos/${{ github.repository }}/commits/$MAIN_SHA/check-runs --jq '{
-              total: .total_count,
-              completed: [.check_runs[] | select(.status == "completed")] | length,
-              success: [.check_runs[] | select(.conclusion == "success" or .conclusion == "skipped")] | length,
-              failure: [.check_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length
-            }')
+            CI_RUN=$(gh run list --workflow ci.yml --branch main --commit "$MAIN_SHA" --event push \
+              --json databaseId,status,conclusion --limit 1 --jq '.[0] // {}')
+            STATUS=$(echo "$CI_RUN" | jq -r '.status // "pending"')
+            CONCLUSION=$(echo "$CI_RUN" | jq -r '.conclusion // ""')
 
-            TOTAL=$(echo "$CHECKS" | jq -r '.total')
-            COMPLETED=$(echo "$CHECKS" | jq -r '.completed')
-            SUCCESS=$(echo "$CHECKS" | jq -r '.success')
-            FAILURE=$(echo "$CHECKS" | jq -r '.failure')
+            echo "CI status: $STATUS ${CONCLUSION:+($CONCLUSION)}"
 
-            echo "CI checks: $COMPLETED/$TOTAL completed, $SUCCESS success/skipped, $FAILURE failure"
-
-            if [ "$FAILURE" -gt 0 ]; then
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                git reset --hard "$MAIN_SHA"
+                exit 0
+              fi
+              echo "CI completed with conclusion: $CONCLUSION"
               exit 1
-            fi
-
-            if [ "$TOTAL" -gt 0 ] && [ "$COMPLETED" -eq "$TOTAL" ]; then
-              break
             fi
 
             sleep 30
           done
-
-      - name: Check for running releases
-        id: check-release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          AUTO_RUNNING=$(gh api repos/${{ github.repository }}/actions/workflows/auto-release.yml/runs \
-            --jq '[.workflow_runs[] | select(.status == "in_progress" and .id != ${{ github.run_id }})] | length')
-          CREATE_RUNNING=$(gh api repos/${{ github.repository }}/actions/workflows/create-release.yml/runs \
-            --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")
-
-          if [ "$AUTO_RUNNING" -gt 0 ] || [ "$CREATE_RUNNING" -gt 0 ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "Timed out waiting for CI on $MAIN_SHA"
+          exit 1
 
       - name: Determine release type
-        if: steps.check-release.outputs.skip != 'true'
         id: release-type
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -134,22 +112,18 @@ jobs:
           echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
 
       - uses: jdx/mise-action@v2
-        if: steps.check-release.outputs.skip != 'true'
         with:
           cache: true
 
       - name: Install dependencies
-        if: steps.check-release.outputs.skip != 'true'
         run: mise run install
 
       - name: Configure git
-        if: steps.check-release.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version and create tag
-        if: steps.check-release.outputs.skip != 'true'
         id: bump
         run: |
           set -euo pipefail
@@ -162,8 +136,11 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Push changes and tag
-        if: steps.check-release.outputs.skip != 'true'
-        run: |
-          git pull --rebase origin main
-          git push origin main
-          git push origin "v${{ steps.bump.outputs.version }}"
+        run: git push --atomic origin main "v${{ steps.bump.outputs.version }}"
+
+  publish:
+    name: Publish release
+    needs: auto-release
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.auto-release.outputs.tag }}

--- a/.github/workflows/release-label.yml
+++ b/.github/workflows/release-label.yml
@@ -12,5 +12,19 @@ jobs:
     name: Require release label
     runs-on: ubuntu-latest
     steps:
-      - name: Release label check disabled
-        run: echo "Release label check temporarily disabled."
+      - name: Check release label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          node <<'NODE'
+          const labels = JSON.parse(process.env.LABELS ?? "[]");
+          const valid = ["release/patch", "release/minor", "release/major", "release/skip"];
+          const found = labels.filter(label => valid.includes(label));
+
+          if (found.length !== 1) {
+            console.error(`Expected exactly one release label (${valid.join(", ")}); found ${found.length}: ${found.join(", ") || "none"}`);
+            process.exit(1);
+          }
+
+          console.log(`Release label: ${found[0]}`);
+          NODE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,15 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to publish
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -21,11 +27,14 @@ jobs:
     steps:
       - name: Get version
         id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Build changelog
         id: changelog
@@ -52,6 +61,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: jdx/mise-action@v2
         with:


### PR DESCRIPTION
Release label enforcement and automatic releases were paused, and the existing flow depended on an unavailable release token.

Restore exactly-one release label validation, bump and tag merged release PRs with the built-in token, and call the reusable npm release workflow directly after CI succeeds.