### PR TITLE
Preserve npm trusted publisher identity

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,10 +10,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: read
-  checks: read
+  actions: write
   contents: write
-  id-token: write
   pull-requests: read
 
 jobs:
@@ -139,8 +137,12 @@ jobs:
         run: git push --atomic origin main "v${{ steps.bump.outputs.version }}"
 
   publish:
-    name: Publish release
+    name: Trigger release
     needs: auto-release
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ needs.auto-release.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.auto-release.outputs.tag }}
+        run: gh workflow run release.yml --ref main -f tag="$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag:
         description: Release tag to publish


### PR DESCRIPTION
The label-driven release invoked release.yml as a reusable workflow, so npm saw the caller workflow identity and rejected Trusted Publisher authentication. This left v3.8.0 unpublished and its GitHub release in draft.

Dispatch release.yml as a standalone workflow instead, preserving its configured OIDC identity while retaining automatic release handoff.