### PR TITLE
Set repository for release dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -144,5 +144,6 @@ jobs:
       - name: Dispatch release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.auto-release.outputs.tag }}
         run: gh workflow run release.yml --ref main -f tag="$TAG"


### PR DESCRIPTION
The standalone release dispatch failed because its job had no checkout and gh could not infer a repository.

Set GH_REPO explicitly so the automatic handoff can dispatch release.yml without adding an unnecessary checkout.