### PR TITLE
Reuse file-operation connections across sequential operations

### DIFF
--- a/src/core/files-ws-client.ts
+++ b/src/core/files-ws-client.ts
@@ -61,6 +61,8 @@ export class FilesRemoteError extends Error {
 }
 
 export interface FilesWsConnection {
+  /** Whether the socket is still open and usable for another operation. */
+  isOpen(): boolean;
   /** Send a request and resolve with the reply frame's `data` value. */
   call(type: string, data: unknown): Promise<unknown>;
   /**
@@ -101,7 +103,8 @@ const sleep = (ms: number): Promise<void> =>
  * token-extraction contract; a `files:*`-scoped token authorizes the path.
  *
  * The bridge handles one request at a time per connection (uploads are modal
- * server-side), so callers should open a connection per operation.
+ * server-side), so callers run one operation at a time and may reuse the
+ * connection for the next one while it is still open.
  */
 export function connectFilesWs(args: {
   config: NormalizedRailwayClientConfig;
@@ -130,6 +133,7 @@ export function connectFilesWs(args: {
     };
 
     const closeSocket = () => {
+      closed = true;
       try {
         socket.close(1000, "");
       } catch {
@@ -380,6 +384,8 @@ export function connectFilesWs(args: {
         if (completed) arm();
         return done;
       },
+
+      isOpen: () => opened && !closed,
 
       close: closeSocket,
     };

--- a/src/sandbox/files.ts
+++ b/src/sandbox/files.ts
@@ -45,10 +45,10 @@ type FilesScope = "files:read" | "files:read files:write";
 let constructFiles: (context: FilesContext) => SandboxFiles;
 
 /**
- * How long an idle pooled `/ws/files` connection lingers before closing.
+ * How long an idle pooled file-session connection lingers before closing.
  * Long enough to carry a burst of sequential operations on one connection
- * (tcp-proxy rate-limits new WS connections per IP), short enough that a
- * script's process exit is barely delayed by an open socket.
+ * (the platform rate-limits new connections per client), short enough that
+ * a script's process exit is barely delayed by an open socket.
  */
 const FILES_IDLE_CLOSE_MS = 2_000;
 
@@ -64,11 +64,11 @@ interface PooledFilesConnection {
 
 /**
  * File operations on a live sandbox, exposed as `sandbox.files`. Operations
- * run one at a time per tcp-proxy `/ws/files` session (the bridge serves one
- * request per connection), but sessions are pooled: a finished operation's
- * connection lingers briefly and the next operation reuses it instead of
- * minting a new token and dialing again. Concurrent operations still run
- * independently on their own connections.
+ * run one at a time per file-session connection (the server serves one
+ * request per connection), but connections are pooled: a finished
+ * operation's connection lingers briefly and the next operation reuses it
+ * instead of minting a new token and dialing again. Concurrent operations
+ * still run independently on their own connections.
  *
  * Paths are absolute within the sandbox filesystem. Content streams in
  * 64KB frames both ways: pushes accept streams without buffering, and
@@ -374,14 +374,17 @@ export class SandboxFiles {
    */
   async #connect(scope: FilesScope): Promise<FilesWsConnection> {
     for (;;) {
+      // An rw-scoped token covers read-only operations too.
       const index = this.#idleConnections.findIndex(
-        entry => entry.scope === "files:read files:write" || entry.scope === scope,
+        entry =>
+          entry.scope === scope || entry.scope === "files:read files:write",
       );
       if (index === -1) break;
       const [entry] = this.#idleConnections.splice(index, 1);
-      if (entry!.idleTimer) clearTimeout(entry!.idleTimer);
-      if (entry!.connection.isOpen()) return this.#lease(entry!);
-      entry!.connection.close();
+      if (!entry) break;
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+      if (entry.connection.isOpen()) return this.#lease(entry);
+      entry.connection.close();
     }
     return this.#lease({ connection: await this.#dial(scope), scope });
   }
@@ -389,9 +392,9 @@ export class SandboxFiles {
   /**
    * Wraps a pooled entry so `close()` releases instead of destroying. Only a
    * connection whose every operation succeeded is worth pooling: a failure
-   * may have poisoned the bridge's upstream stream even when the socket
-   * itself stays open (the server reports that as "connection lost"), and
-   * retry paths count on getting a genuinely fresh session.
+   * may have poisoned the server's stream to the sandbox even when the
+   * socket itself stays open (reported as "connection lost"), and retry
+   * paths count on getting a genuinely fresh session.
    */
   #lease(entry: PooledFilesConnection): FilesWsConnection {
     let released = false;

--- a/src/sandbox/files.ts
+++ b/src/sandbox/files.ts
@@ -45,10 +45,30 @@ type FilesScope = "files:read" | "files:read files:write";
 let constructFiles: (context: FilesContext) => SandboxFiles;
 
 /**
- * File operations on a live sandbox, exposed as `sandbox.files`. Each
- * operation mints a short-lived `files`-scoped token and opens its own
- * tcp-proxy `/ws/files` session (the bridge serves one request per
- * connection), so concurrent operations run independently.
+ * How long an idle pooled `/ws/files` connection lingers before closing.
+ * Long enough to carry a burst of sequential operations on one connection
+ * (tcp-proxy rate-limits new WS connections per IP), short enough that a
+ * script's process exit is barely delayed by an open socket.
+ */
+const FILES_IDLE_CLOSE_MS = 2_000;
+
+/** Idle connections kept beyond this are closed on release instead of pooled. */
+const FILES_MAX_IDLE_CONNECTIONS = 4;
+
+/** A pooled files session: the raw connection plus the scope its token holds. */
+interface PooledFilesConnection {
+  connection: FilesWsConnection;
+  scope: FilesScope;
+  idleTimer?: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * File operations on a live sandbox, exposed as `sandbox.files`. Operations
+ * run one at a time per tcp-proxy `/ws/files` session (the bridge serves one
+ * request per connection), but sessions are pooled: a finished operation's
+ * connection lingers briefly and the next operation reuses it instead of
+ * minting a new token and dialing again. Concurrent operations still run
+ * independently on their own connections.
  *
  * Paths are absolute within the sandbox filesystem. Content streams in
  * 64KB frames both ways: pushes accept streams without buffering, and
@@ -57,6 +77,7 @@ let constructFiles: (context: FilesContext) => SandboxFiles;
  */
 export class SandboxFiles {
   readonly #context: FilesContext;
+  readonly #idleConnections: PooledFilesConnection[] = [];
 
   /** Constructed by `Sandbox#files`; not constructible from outside the SDK. */
   private constructor(context: FilesContext) {
@@ -344,8 +365,88 @@ export class SandboxFiles {
     });
   }
 
-  /** Mints a files-scoped token and opens a `/ws/files` session with it. */
+  /**
+   * Leases a `/ws/files` session: an idle pooled connection whose token
+   * covers `scope` when one exists, otherwise a fresh dial. The returned
+   * connection's `close()` releases it back to the pool (dead or surplus
+   * connections are really closed), so callers manage it exactly like an
+   * owned connection.
+   */
   async #connect(scope: FilesScope): Promise<FilesWsConnection> {
+    for (;;) {
+      const index = this.#idleConnections.findIndex(
+        entry => entry.scope === "files:read files:write" || entry.scope === scope,
+      );
+      if (index === -1) break;
+      const [entry] = this.#idleConnections.splice(index, 1);
+      if (entry!.idleTimer) clearTimeout(entry!.idleTimer);
+      if (entry!.connection.isOpen()) return this.#lease(entry!);
+      entry!.connection.close();
+    }
+    return this.#lease({ connection: await this.#dial(scope), scope });
+  }
+
+  /**
+   * Wraps a pooled entry so `close()` releases instead of destroying. Only a
+   * connection whose every operation succeeded is worth pooling: a failure
+   * may have poisoned the bridge's upstream stream even when the socket
+   * itself stays open (the server reports that as "connection lost"), and
+   * retry paths count on getting a genuinely fresh session.
+   */
+  #lease(entry: PooledFilesConnection): FilesWsConnection {
+    let released = false;
+    let failed = false;
+    const guard = <A extends unknown[], R>(
+      operation: (...args: A) => Promise<R>,
+    ): ((...args: A) => Promise<R>) => {
+      return async (...args) => {
+        try {
+          return await operation(...args);
+        } catch (error) {
+          failed = true;
+          throw error;
+        }
+      };
+    };
+    return {
+      isOpen: () => entry.connection.isOpen(),
+      call: guard((type, data) => entry.connection.call(type, data)),
+      read: guard((data, onChunk) => entry.connection.read(data, onChunk)),
+      write: guard((start, chunks) => entry.connection.write(start, chunks)),
+      close: () => {
+        if (released) return;
+        released = true;
+        if (failed) {
+          entry.connection.close();
+          return;
+        }
+        this.#release(entry);
+      },
+    };
+  }
+
+  #release(entry: PooledFilesConnection): void {
+    if (
+      !entry.connection.isOpen() ||
+      this.#idleConnections.length >= FILES_MAX_IDLE_CONNECTIONS
+    ) {
+      entry.connection.close();
+      return;
+    }
+    const timer = setTimeout(() => {
+      const index = this.#idleConnections.indexOf(entry);
+      if (index !== -1) this.#idleConnections.splice(index, 1);
+      entry.connection.close();
+    }, FILES_IDLE_CLOSE_MS);
+    // Node timers hold the event loop open; unref so the linger itself never
+    // delays process exit (the socket still lingers at most the idle window).
+    (timer as { unref?: () => void }).unref?.();
+    entry.idleTimer = timer;
+    this.#idleConnections.push(entry);
+  }
+
+  /** Mints a files-scoped token and opens a `/ws/files` session with it. */
+  async #dial(scope: FilesScope): Promise<FilesWsConnection> {
     const { config, environmentId, sandboxId } = this.#context;
     const input: RailwayGenerateShellTokenMutationVariables["input"] = {
       environmentId,

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -126,7 +126,6 @@ describe("files.read", () => {
     });
     expect(socket.url).toBe("wss://ssh.railway.com:2226/ws/files");
     expect(socket.protocols).toEqual(["railway-shell", "jwt_0"]);
-    // A successful operation's connection is pooled for reuse, not closed.
     expect(socket.readyState).toBe(1);
   });
 
@@ -241,7 +240,6 @@ describe("files.read", () => {
     expect((await reader.read()).value).toEqual(new Uint8Array([7]));
     expect((await reader.read()).value).toEqual(new Uint8Array([8]));
     expect((await reader.read()).done).toBe(true);
-    // A successful operation's connection is pooled for reuse, not closed.
     expect(socket.readyState).toBe(1);
   });
 
@@ -469,7 +467,6 @@ describe("files.write", () => {
         scope: "files:read files:write",
       },
     });
-    // A successful operation's connection is pooled for reuse, not closed.
     expect(socket.readyState).toBe(1);
   });
 
@@ -879,7 +876,6 @@ describe("files metadata ops", () => {
     socket.serverReply("stat_result", "1", entry);
     await expect(statPromise).resolves.toEqual(entry);
 
-    // The pooled connection carries the follow-up op; request ids continue.
     const existsPromise = sandbox.files.exists("/nope");
     expect(await socket.nextRequest()).toEqual({
       type: "stat",
@@ -888,7 +884,6 @@ describe("files metadata ops", () => {
     });
     socket.serverError("2", "file does not exist");
     await expect(existsPromise).resolves.toBe(false);
-    // A failed op's connection is closed, never pooled.
     expect(socket.readyState).toBe(3);
   });
 
@@ -905,7 +900,6 @@ describe("files metadata ops", () => {
     socket.serverReply("ok", "1");
     await expect(mkdirPromise).resolves.toBeUndefined();
 
-    // Successive successful mutations reuse the pooled connection.
     const removePromise = sandbox.files.remove("/a/b/c");
     expect(await socket.nextRequest()).toEqual({
       type: "rm",

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -126,8 +126,8 @@ describe("files.read", () => {
     });
     expect(socket.url).toBe("wss://ssh.railway.com:2226/ws/files");
     expect(socket.protocols).toEqual(["railway-shell", "jwt_0"]);
-    // The per-op connection is closed once the read settles.
-    expect(socket.readyState).toBe(3);
+    // A successful operation's connection is pooled for reuse, not closed.
+    expect(socket.readyState).toBe(1);
   });
 
   it("returns bytes for format=bytes, including the end-frame payload", async () => {
@@ -241,7 +241,8 @@ describe("files.read", () => {
     expect((await reader.read()).value).toEqual(new Uint8Array([7]));
     expect((await reader.read()).value).toEqual(new Uint8Array([8]));
     expect((await reader.read()).done).toBe(true);
-    expect(socket.readyState).toBe(3);
+    // A successful operation's connection is pooled for reuse, not closed.
+    expect(socket.readyState).toBe(1);
   });
 
   it("aborts the transfer when the stream is cancelled", async () => {
@@ -468,7 +469,8 @@ describe("files.write", () => {
         scope: "files:read files:write",
       },
     });
-    expect(socket.readyState).toBe(3);
+    // A successful operation's connection is pooled for reuse, not closed.
+    expect(socket.readyState).toBe(1);
   });
 
   it("re-chunks large payloads to 64KB frames with the last one end-tagged", async () => {
@@ -858,11 +860,11 @@ describe("files metadata ops", () => {
   });
 
   it("stats a path and reports missing ones via exists()", async () => {
-    const { sandbox, ws } = await filesSandbox(2);
+    const { sandbox, ws } = await filesSandbox();
 
     const statPromise = sandbox.files.stat("/app/index.ts");
-    const socket1 = await ws.nextSocket();
-    expect(await socket1.nextRequest()).toEqual({
+    const socket = await ws.nextSocket();
+    expect(await socket.nextRequest()).toEqual({
       type: "stat",
       id: "1",
       data: { path: "/app/index.ts" },
@@ -874,47 +876,52 @@ describe("files metadata ops", () => {
       isDir: false,
       modTime: "2026-06-11T00:00:00Z",
     };
-    socket1.serverReply("stat_result", "1", entry);
+    socket.serverReply("stat_result", "1", entry);
     await expect(statPromise).resolves.toEqual(entry);
 
+    // The pooled connection carries the follow-up op; request ids continue.
     const existsPromise = sandbox.files.exists("/nope");
-    const socket2 = await ws.nextSocket();
-    await socket2.nextRequest();
-    socket2.serverError("1", "file does not exist");
+    expect(await socket.nextRequest()).toEqual({
+      type: "stat",
+      id: "2",
+      data: { path: "/nope" },
+    });
+    socket.serverError("2", "file does not exist");
     await expect(existsPromise).resolves.toBe(false);
+    // A failed op's connection is closed, never pooled.
+    expect(socket.readyState).toBe(3);
   });
 
   it("creates directories, removes, and renames", async () => {
-    const { sandbox, ws } = await filesSandbox(3);
+    const { sandbox, ws } = await filesSandbox();
 
     const mkdirPromise = sandbox.files.mkdir("/a/b/c");
-    const socket1 = await ws.nextSocket();
-    expect(await socket1.nextRequest()).toEqual({
+    const socket = await ws.nextSocket();
+    expect(await socket.nextRequest()).toEqual({
       type: "mkdir",
       id: "1",
       data: { path: "/a/b/c" },
     });
-    socket1.serverReply("ok", "1");
+    socket.serverReply("ok", "1");
     await expect(mkdirPromise).resolves.toBeUndefined();
 
+    // Successive successful mutations reuse the pooled connection.
     const removePromise = sandbox.files.remove("/a/b/c");
-    const socket2 = await ws.nextSocket();
-    expect(await socket2.nextRequest()).toEqual({
+    expect(await socket.nextRequest()).toEqual({
       type: "rm",
-      id: "1",
+      id: "2",
       data: { path: "/a/b/c" },
     });
-    socket2.serverReply("ok", "1");
+    socket.serverReply("ok", "2");
     await expect(removePromise).resolves.toBeUndefined();
 
     const renamePromise = sandbox.files.rename("/old.txt", "/new.txt");
-    const socket3 = await ws.nextSocket();
-    expect(await socket3.nextRequest()).toEqual({
+    expect(await socket.nextRequest()).toEqual({
       type: "rename",
-      id: "1",
+      id: "3",
       data: { old: "/old.txt", new: "/new.txt" },
     });
-    socket3.serverReply("ok", "1");
+    socket.serverReply("ok", "3");
     await expect(renamePromise).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
Each `sandbox.files` operation previously minted its own token and opened its own WebSocket connection. New connections are rate-limited per client, so a burst of file operations (roughly ten or more within a minute) could start failing with `files WebSocket connection failed` until the limiter recovered.

- `sandbox.files` now pools connections: a finished operation's connection lingers for 2 seconds and the next operation reuses it, so a sequential burst rides one connection and one token. Concurrent operations still run independently on their own connections; at most 4 idle connections are kept.
- Only connections whose every operation succeeded are pooled. Any failure closes the connection, so transfer retry logic keeps its fresh-session semantics.
- The idle linger never delays process exit (unref'd timers).

Live e2e suite passes with the pooled client.
