### PR TITLE
test: accept mise install-dir node resolution in exec PATH e2e

### DIFF
--- a/tests/sandbox-exec.e2e.test.ts
+++ b/tests/sandbox-exec.e2e.test.ts
@@ -65,7 +65,9 @@ describe.runIf(live)("exec e2e (live)", () => {
       env: { PROBE: "1" },
     });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("/mise/shims/node");
+    // mise resolves node via the shim or, once activated, the install dir;
+    // either proves the image PATH survived cwd/env.
+    expect(result.stdout).toMatch(/\/mise\/(shims|installs)\/(.*\/)?node/);
     expect(result.stdout).toContain("/mise");
   }, 90_000);
 


### PR DESCRIPTION
Newer mise activation resolves `node` through the tool's install bin dir instead of the shim, so the live exec PATH test failed on string match while the command itself succeeded (exit 0, node found). Accept either resolution path — both prove the image PATH survives cwd/env.