### PR TITLE
Honor export const partial so omit=delete is per-file

### DIFF
--- a/src/iac/change-set.ts
+++ b/src/iac/change-set.ts
@@ -1,5 +1,14 @@
 import { composePatch, graphToEnvironmentConfig } from "./compiler.js";
 import type { DatabaseNode, GraphCompileOptions, RailwayGraph, ResourceAddress, ResourceNode, ServiceNode, VariableValue, VolumeNode } from "./graph.js";
+import {
+  effectivePartial,
+  foreignResourceMessage,
+  hasNamedPartials,
+  namelessFileMessage,
+  ownerOf,
+  PROJECT_PARTIAL,
+  type IacPartials,
+} from "./partial.js";
 import type { EnvironmentConfig } from "./schema.js";
 
 // Wire-contract version for the RailwayChangeSet exchanged with backboard.
@@ -17,6 +26,10 @@ export interface RailwayChangeSet {
   version: RailwayChangeSetVersion;
   changes: RailwayChange[];
   diagnostics: ChangeDiagnostic[];
+  /** File identity from `export const partial`. Omitted means whole-project. */
+  partial?: string;
+  /** Addresses this file declares — server binds them to `partial` on apply. */
+  declared?: ResourceAddress[];
 }
 
 export type RailwayChange =
@@ -85,14 +98,47 @@ export interface ChangeDiagnostic {
   message: string;
 }
 
-export function diffGraphs({ current, desired, revealValues = false }: { current: RailwayGraph; desired: RailwayGraph; revealValues?: boolean }): RailwayChangeSet {
+export function diffGraphs({
+  current,
+  desired,
+  revealValues = false,
+  partial,
+  owners,
+}: {
+  current: RailwayGraph;
+  desired: RailwayGraph;
+  revealValues?: boolean;
+  /** `export const partial` from the file. Omitted means this file owns the whole environment. */
+  partial?: string;
+  owners?: IacPartials;
+}): RailwayChangeSet {
   const changes: RailwayChange[] = [];
   const diagnostics: ChangeDiagnostic[] = [];
   const currentByAddress = new Map(current.resources.map(resource => [resource.address, resource]));
   const desiredByAddress = new Map(desired.resources.map(resource => [resource.address, resource]));
+  const p = effectivePartial(partial);
+  const declared = desired.resources.map(resource => resource.address);
+
+  if (p === PROJECT_PARTIAL && hasNamedPartials(owners)) {
+    diagnostics.push({
+      severity: "error",
+      path: "partial",
+      message: namelessFileMessage(),
+    });
+    return changeSetResult({ changes: [], diagnostics, declared, ...(partial ? { partial } : {}) });
+  }
 
   for (const resource of desired.resources) {
     const previous = currentByAddress.get(resource.address);
+    const owner = ownerOf(owners, resource.address);
+    if (owner != null && owner !== p) {
+      diagnostics.push({
+        severity: "error",
+        path: `resources.${resource.address}`,
+        message: foreignResourceMessage(resource.address, owner),
+      });
+      continue;
+    }
     if (previous && isManagedByRepoConfig(previous)) {
       diagnostics.push({
         severity: "error",
@@ -151,6 +197,7 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
 
   for (const resource of current.resources) {
     if (desiredByAddress.has(resource.address)) continue;
+    if (p !== PROJECT_PARTIAL && ownerOf(owners, resource.address) !== p) continue;
     // Volumes hold data, and database volumes are realized by Backboard without ever
     // appearing in authored config — a plan against a postgres() database would otherwise
     // delete its volume on every apply. Never plan an implicit volume deletion; deleting
@@ -180,7 +227,27 @@ export function diffGraphs({ current, desired, revealValues = false }: { current
     });
   }
 
-  return { version: RAILWAY_CHANGE_SET_VERSION, changes, diagnostics };
+  return changeSetResult({ changes, diagnostics, declared, ...(partial ? { partial } : {}) });
+}
+
+function changeSetResult({
+  changes,
+  diagnostics,
+  partial,
+  declared,
+}: {
+  changes: RailwayChange[];
+  diagnostics: ChangeDiagnostic[];
+  partial?: string;
+  declared: ResourceAddress[];
+}): RailwayChangeSet {
+  return {
+    version: RAILWAY_CHANGE_SET_VERSION,
+    changes,
+    diagnostics,
+    ...(partial ? { partial } : {}),
+    declared,
+  };
 }
 
 export function changeSetToGraph({ current, changeSet }: { current: RailwayGraph; changeSet: RailwayChangeSet }): RailwayGraph {

--- a/src/iac/client.ts
+++ b/src/iac/client.ts
@@ -22,6 +22,8 @@ export interface CurrentEnvironmentResult {
   bucketNamesById: Record<string, string>;
   bucketGroupIdsById: Record<string, string>;
   customDomainsByServiceId: Record<string, Record<string, { port?: number }>>;
+  /** Resource address → partial name. `*` is the whole-project owner. Absent on older servers. */
+  iacPartials?: Record<string, string> | undefined;
 }
 
 export interface StagedPatchResult {
@@ -72,17 +74,14 @@ export class IacClient {
   }
 
   async getCurrentEnvironment(environmentId: string, options: { decryptVariables?: boolean } = {}): Promise<CurrentEnvironmentResult> {
-    const data = await gql<{
-      environment: { id: string; name?: string; projectId?: string; config: EnvironmentConfig; configEtag?: string; canvasGroupRefs?: Record<string, string> };
-    }, { environmentId: string; decryptVariables: boolean }>(this.#config, `query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
-      environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs }
-    }`, { environmentId, decryptVariables: options.decryptVariables ?? false });
+    const data = await this.queryEnvironmentConfig(environmentId, options.decryptVariables ?? false);
 
     const projectName = data.environment.projectId ? await this.getProjectName(data.environment.projectId) : undefined;
     const services = data.environment.projectId ? await this.getProjectServices(data.environment.projectId) : [];
     const volumes = data.environment.projectId ? await this.getProjectVolumes(data.environment.projectId) : [];
     const buckets = data.environment.projectId ? await this.getProjectBuckets(data.environment.projectId) : [];
     const customDomainsByServiceId = data.environment.projectId ? await this.getEnvironmentCustomDomains(data.environment.projectId, environmentId, services) : {};
+    const iacPartials = parseIacPartials(data.environment.iacPartials);
     return {
       projectId: data.environment.projectId,
       projectName,
@@ -99,7 +98,51 @@ export class IacClient {
       bucketGroupIdsById: Object.fromEntries(buckets.flatMap(bucket => bucket.groupId ? [[bucket.id, bucket.groupId] as const] : [])),
       customDomainsByServiceId,
       ...(data.environment.configEtag ? { configEtag: data.environment.configEtag } : {}),
+      ...(iacPartials ? { iacPartials } : {}),
     };
+  }
+
+  private async queryEnvironmentConfig(environmentId: string, decryptVariables: boolean): Promise<{
+    environment: {
+      id: string;
+      name?: string;
+      projectId?: string;
+      config: EnvironmentConfig;
+      configEtag?: string;
+      canvasGroupRefs?: Record<string, string>;
+      iacPartials?: unknown;
+    };
+  }> {
+    const variables = { environmentId, decryptVariables };
+    try {
+      return await gql<{
+        environment: {
+          id: string;
+          name?: string;
+          projectId?: string;
+          config: EnvironmentConfig;
+          configEtag?: string;
+          canvasGroupRefs?: Record<string, string>;
+          iacPartials?: unknown;
+        };
+      }, { environmentId: string; decryptVariables: boolean }>(this.#config, `query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
+        environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs iacPartials }
+      }`, variables);
+    } catch (error) {
+      if (!isUnknownGraphQLField(error, "iacPartials")) throw error;
+      return await gql<{
+        environment: {
+          id: string;
+          name?: string;
+          projectId?: string;
+          config: EnvironmentConfig;
+          configEtag?: string;
+          canvasGroupRefs?: Record<string, string>;
+        };
+      }, { environmentId: string; decryptVariables: boolean }>(this.#config, `query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
+        environment(id: $environmentId) { id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs }
+      }`, variables);
+    }
   }
 
   async getStagedPatch(environmentId: string, options: { decryptVariables?: boolean } = {}): Promise<StagedPatchResult> {
@@ -298,6 +341,23 @@ async function gql<TResult, TVariables>(config: NormalizedRailwayClientConfig, s
 function isStaleBaseError(error: unknown): boolean {
   if (!(error instanceof RailwayGraphQLError)) return false;
   return error.errors.some(item => item.extensions?.code === STALE_ENVIRONMENT_BASE_CODE);
+}
+
+function isUnknownGraphQLField(error: unknown, field: string): boolean {
+  if (!(error instanceof RailwayGraphQLError)) return false;
+  return error.errors.some(item =>
+    typeof item.message === "string" &&
+    item.message.includes(field) &&
+    /Cannot query field|Unknown field|cannot query field/i.test(item.message),
+  );
+}
+
+function parseIacPartials(value: unknown): Record<string, string> | undefined {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function extractVolumeIdsByServiceName({ currentConfig, serviceIdsByName }: { currentConfig?: EnvironmentConfig; serviceIdsByName: Record<string, string> }): Record<string, string> {

--- a/src/iac/evaluator.ts
+++ b/src/iac/evaluator.ts
@@ -2,18 +2,18 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { graphToEnvironmentConfig, projectDefinitionToGraph } from "./compiler.js";
 import type { CompileResult, GraphCompileOptions, ProjectDefinition } from "./graph.js";
+import { parsePartialExport } from "./partial.js";
 import { createRailwayContext, project as projectFactory, type RailwayContextInput, type RailwayProgram } from "./sdk.js";
 
 export async function evaluateRailwayFile(filePath: string, options: GraphCompileOptions & { context?: RailwayContextInput } = {}): Promise<CompileResult> {
   const absolutePath = path.resolve(filePath);
-  const mod = await importRailwayFile(absolutePath) as {
-    default?: RailwayProgram | ProjectDefinition;
-  };
+  const mod = await importRailwayFile(absolutePath);
+  const partial = parsePartialExport(mod);
   const exported = unwrapDefaultExport(mod) as RailwayProgram | ProjectDefinition;
   const definition = await resolveDefinition(exported, options.context);
   const graph = projectDefinitionToGraph(definition);
   const desiredConfig = graphToEnvironmentConfig(graph, options);
-  return { graph, desiredConfig };
+  return { graph, desiredConfig, ...(partial ? { partial } : {}) };
 }
 
 async function importRailwayFile(absolutePath: string): Promise<unknown> {

--- a/src/iac/graph.ts
+++ b/src/iac/graph.ts
@@ -140,6 +140,7 @@ export interface GraphCompileOptions {
 export interface CompileResult {
   graph: RailwayGraph;
   desiredConfig: EnvironmentConfig;
+  partial?: string;
 }
 
 export interface GraphIndex {

--- a/src/iac/index.ts
+++ b/src/iac/index.ts
@@ -4,6 +4,7 @@ export * from "./compiler.js";
 export * from "./diff.js";
 export * from "./evaluator.js";
 export * from "./graph.js";
+export * from "./partial.js";
 export * from "./project.js";
 export * from "./runner.js";
 export * from "./schema.js";

--- a/src/iac/partial.ts
+++ b/src/iac/partial.ts
@@ -1,0 +1,71 @@
+import type { ResourceAddress } from "./graph.js";
+
+/** Stored owner for a file that omitted `export const partial` (whole environment). */
+export const PROJECT_PARTIAL = "*";
+
+const PARTIAL_NAME = /^[a-zA-Z0-9._-]{1,64}$/;
+
+export type IacPartials = Record<string, string>;
+
+export function parsePartialExport(mod: unknown): string | undefined {
+  const seen = new Set<unknown>();
+  let current: unknown = mod;
+  while (current != null && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    if ("partial" in record || "PARTIAL" in record || "Partial" in record) {
+      const value = record.partial ?? record.PARTIAL ?? record.Partial;
+      if (value === undefined || value === null) return undefined;
+      if (typeof value !== "string" || value === PROJECT_PARTIAL || !PARTIAL_NAME.test(value)) {
+        throw new Error(
+          `Invalid partial export: ${JSON.stringify(value)}. Use a 1–64 character name matching [a-zA-Z0-9._-]+.`,
+        );
+      }
+      return value;
+    }
+    if (!("default" in record)) break;
+    current = record.default;
+  }
+  return undefined;
+}
+
+export function hasNamedPartials(owners: IacPartials | undefined): boolean {
+  return Object.values(owners ?? {}).some(owner => owner !== PROJECT_PARTIAL);
+}
+
+export function ownerOf(owners: IacPartials | undefined, address: string): string | undefined {
+  return owners?.[address];
+}
+
+export function isForeign(owners: IacPartials | undefined, address: string, partial: string): boolean {
+  const owner = ownerOf(owners, address);
+  return owner != null && owner !== partial;
+}
+
+export function effectivePartial(partial: string | undefined): string {
+  return partial ?? PROJECT_PARTIAL;
+}
+
+export function declaredAddresses(addresses: readonly string[]): ResourceAddress[] {
+  return [...addresses] as ResourceAddress[];
+}
+
+export function foreignResourceMessage(address: string, owner: string): string {
+  const dot = address.indexOf(".");
+  const type = dot > 0 ? address.slice(0, dot) : "resource";
+  const name = dot > 0 ? address.slice(dot + 1) : address;
+  return `Cannot manage ${type} "${name}": already managed by partial "${owner}".`;
+}
+
+export function namelessFileMessage(): string {
+  return 'This environment already has named IaC partials. Export `const partial = "<name>"` from this file instead of managing the whole project.';
+}
+
+export function needsPartialClaimApply(
+  declared: readonly string[],
+  owners: IacPartials | undefined,
+  partial: string | undefined,
+): boolean {
+  const p = effectivePartial(partial);
+  return declared.some(address => ownerOf(owners, address) !== p);
+}

--- a/src/iac/project.ts
+++ b/src/iac/project.ts
@@ -38,14 +38,15 @@ export interface EvaluatedRailwayProjectSnapshot {
   file: string;
   graph: RailwayGraph;
   desiredConfig: EnvironmentConfig;
+  partial?: string;
 }
 
 export async function evaluateRailwayProject(
   options: EvaluatedRailwayProjectOptions = {},
 ): Promise<EvaluatedRailwayProject> {
   const file = options.file ? path.resolve(options.file) : findRailwayFile(options.cwd);
-  const { graph, desiredConfig } = await evaluateRailwayFile(file, options);
-  return new EvaluatedRailwayProject({ file, graph, desiredConfig });
+  const { graph, desiredConfig, partial } = await evaluateRailwayFile(file, options);
+  return new EvaluatedRailwayProject({ file, graph, desiredConfig, ...(partial ? { partial } : {}) });
 }
 
 export function findRailwayFile(cwd = process.cwd()): string {
@@ -68,11 +69,13 @@ export class EvaluatedRailwayProject {
   readonly file: string;
   readonly graph: RailwayGraph;
   readonly desiredConfig: EnvironmentConfig;
+  readonly partial?: string;
 
   constructor(snapshot: EvaluatedRailwayProjectSnapshot) {
     this.file = snapshot.file;
     this.graph = snapshot.graph;
     this.desiredConfig = snapshot.desiredConfig;
+    if (snapshot.partial !== undefined) this.partial = snapshot.partial;
   }
 
   get name(): string {
@@ -142,6 +145,7 @@ export class EvaluatedRailwayProject {
       file: this.file,
       graph: this.graph,
       desiredConfig: this.desiredConfig,
+      ...(this.partial ? { partial: this.partial } : {}),
     };
   }
 }

--- a/src/iac/runner.ts
+++ b/src/iac/runner.ts
@@ -2,6 +2,7 @@ import { diffGraphs, renderChangeSet, type RailwayChangeSet } from "./change-set
 import { environmentConfigToGraph } from "./compiler.js";
 import { IacClient, type ChangeSetApplyResult, type ChangeSetPreviewResult, type CurrentEnvironmentResult } from "./client.js";
 import { validateGraph, type RailwayGraph } from "./graph.js";
+import { needsPartialClaimApply } from "./partial.js";
 import { evaluateRailwayProject, findRailwayFile } from "./project.js";
 import { renderRailwayGraphTypes } from "./typegen.js";
 import type { EnvironmentConfig } from "./schema.js";
@@ -80,6 +81,8 @@ export interface RailwayIacPlanResponse {
   diff?: string;
   graphTypes?: string;
   diagnostics: RailwayIacRunnerDiagnostic[];
+  /** True when there are no resource ops but unbound declared resources still need to be claimed. */
+  claim?: boolean;
 }
 
 export interface RailwayIacStageResponse extends Omit<RailwayIacPlanResponse, "command"> {
@@ -105,6 +108,7 @@ interface EvaluatedCommandInput {
   file: string;
   graph: RailwayGraph;
   diagnostics: RailwayIacRunnerDiagnostic[];
+  partial?: string;
 }
 
 export async function runRailwayIac(request: RailwayIacRunnerRequest = {}): Promise<RailwayIacRunnerResponse> {
@@ -119,6 +123,7 @@ export async function runRailwayIac(request: RailwayIacRunnerRequest = {}): Prom
       file: evaluated.file,
       graph: evaluated.graph,
       diagnostics: graphDiagnostics(evaluated.graph),
+      ...(evaluated.partial ? { partial: evaluated.partial } : {}),
     };
     return { sdkVersion: SDK_VERSION, ...(await runEvaluatedCommand(command, input)) };
   } catch (error) {
@@ -184,12 +189,18 @@ async function currentRailwayIac({ file, graph: desiredGraph, request, diagnosti
   };
 }
 
-async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics }: EvaluatedCommandInput): Promise<RailwayIacPlanResponse> {
+async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics, partial }: EvaluatedCommandInput): Promise<RailwayIacPlanResponse> {
   const context = requireBackboardContext(request.backboard, "plan");
   const client = new IacClient(clientConfig(context));
   const current = await readCurrentEnvironment(client, context);
   const currentGraph = graphFromCurrentEnvironment(current, desiredGraph);
-  const changeSet = diffGraphs({ current: currentGraph, desired: desiredGraph, revealValues: request.revealValues ?? false });
+  const changeSet = diffGraphs({
+    current: currentGraph,
+    desired: desiredGraph,
+    revealValues: request.revealValues ?? false,
+    ...(partial ? { partial } : {}),
+    ...(current.iacPartials ? { owners: current.iacPartials } : {}),
+  });
   const allDiagnostics = [...diagnostics, ...changeSetDiagnostics(changeSet)];
   const { config: _config, ...currentEnvironment } = current;
   const hasErrors = !hasNoErrors(allDiagnostics);
@@ -197,7 +208,14 @@ async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics 
     ? await client.previewChangeSet({ environmentId: context.environmentId, changeSet })
     : undefined;
 
-  const previewedChangeSet = preview?.changeSet ?? changeSet;
+  const previewedChangeSet = preview?.changeSet
+    ? {
+        ...preview.changeSet,
+        ...(changeSet.partial ? { partial: changeSet.partial } : {}),
+        ...(changeSet.declared ? { declared: changeSet.declared } : {}),
+      }
+    : changeSet;
+  const claim = needsPartialClaimApply(changeSet.declared ?? [], current.iacPartials, partial);
 
   return {
     ok: !hasErrors,
@@ -213,6 +231,7 @@ async function planRailwayIac({ file, graph: desiredGraph, request, diagnostics 
     diff: renderChangeSet(previewedChangeSet),
     ...(request.includeTypes ? { graphTypes: renderRailwayGraphTypes(desiredGraph) } : {}),
     diagnostics: allDiagnostics,
+    ...(claim ? { claim: true } : {}),
   };
 }
 
@@ -227,7 +246,8 @@ async function stageRailwayIac(input: EvaluatedCommandInput): Promise<RailwayIac
 
 async function applyRailwayIac(input: EvaluatedCommandInput): Promise<RailwayIacApplyResponse> {
   const planned = await planRailwayIac(input);
-  if (!planned.ok || !planned.changeSet || planned.changeSet.changes.length === 0) {
+  const claimed = planned.claim === true;
+  if (!planned.ok || !planned.changeSet || (planned.changeSet.changes.length === 0 && !claimed)) {
     return { ...planned, command: "apply" };
   }
 

--- a/tests/iac.test.ts
+++ b/tests/iac.test.ts
@@ -413,6 +413,117 @@ describe("Railway IaC", () => {
     expect(deletion).toMatchObject({ kind: "resource.delete", address: "service.api", severity: "destructive" });
   });
 
+  it("does not delete resources owned by another partial", () => {
+    const current = environmentConfigToGraph({
+      services: { api: { source: { repo: "acme/api" } }, worker: { source: { repo: "acme/worker" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("api", { source: github("acme/api") })],
+    }));
+
+    const { changes, diagnostics, declared } = diffGraphs({
+      current,
+      desired,
+      partial: "api",
+      owners: { "service.api": "api", "service.worker": "worker" },
+    });
+    expect(changes.filter(change => change.kind === "resource.delete")).toEqual([]);
+    expect(diagnostics).toEqual([]);
+    expect(declared).toEqual(["service.api"]);
+  });
+
+  it("errors when a partial declares a resource owned by another partial", () => {
+    const current = environmentConfigToGraph({
+      services: { api: { source: { repo: "acme/api" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("api", { source: github("acme/api") })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({
+      current,
+      desired,
+      partial: "worker",
+      owners: { "service.api": "api" },
+    });
+    expect(changes).toEqual([]);
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      severity: "error",
+      message: expect.stringContaining('already managed by partial "api"'),
+    }));
+  });
+
+  it("errors when a nameless file runs in an environment that already has named partials", () => {
+    const current = environmentConfigToGraph({
+      services: { api: { source: { repo: "acme/api" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("api", { source: github("acme/api") })],
+    }));
+
+    const { changes, diagnostics } = diffGraphs({
+      current,
+      desired,
+      owners: { "service.api": "api" },
+    });
+    expect(changes).toEqual([]);
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      severity: "error",
+      path: "partial",
+      message: expect.stringContaining("named IaC partials"),
+    }));
+  });
+
+  it("still deletes omitted resources when this file owns the whole project", () => {
+    const current = environmentConfigToGraph({
+      services: { web: { source: { repo: "railwayapp/demo" } }, api: { source: { repo: "railwayapp/api" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("web", { source: github("railwayapp/demo") })],
+    }));
+
+    const deletion = diffGraphs({
+      current,
+      desired,
+      owners: { "service.web": "*", "service.api": "*" },
+    }).changes.find(change => change.kind === "resource.delete");
+    expect(deletion).toMatchObject({ kind: "resource.delete", address: "service.api" });
+  });
+
+  it("deletes a partial's own omitted service", () => {
+    const current = environmentConfigToGraph({
+      services: { api: { source: { repo: "acme/api" } }, extra: { source: { repo: "acme/extra" } } },
+    }, { projectName: "app" });
+    const desired = projectDefinitionToGraph(project("app", {
+      resources: [service("api", { source: github("acme/api") })],
+    }));
+
+    const deletion = diffGraphs({
+      current,
+      desired,
+      partial: "api",
+      owners: { "service.api": "api", "service.extra": "api" },
+    }).changes.find(change => change.kind === "resource.delete");
+    expect(deletion).toMatchObject({ kind: "resource.delete", address: "service.extra" });
+  });
+
+  it("reads export const partial from the module", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "railway-iac-partial-"));
+    const file = join(dir, "railway.ts");
+    await writeFile(file, `
+      export const partial = "api";
+      export default () => ({
+        name: "app",
+        resources: [{ address: "service.api", type: "service", name: "api" }],
+      });
+    `);
+
+    await expect(evaluateRailwayFile(file)).resolves.toMatchObject({
+      partial: "api",
+      graph: { resources: [{ address: "service.api" }] },
+    });
+  });
+
   it("treats variable removal as destructive and addition as safe", () => {
     const current = environmentConfigToGraph({
       services: { web: { source: { repo: "r" }, variables: { OLD: { value: "1" } } } },


### PR DESCRIPTION
## Summary
- Read `export const partial` / `PARTIAL` / `Partial` from the IaC module.
- Diff skips deletes for resources not owned by this file; foreign creates error.
- Apply sends `partial` + `declared` so Backboard can bind owners. Unknown-field fallback on older APIs.

Depends on the backboard `Environment.iacPartials` draft.

## Test plan
- [ ] `mise run test` (offline) — includes new partial cases in `tests/iac.test.ts`
- [ ] Plan against an env with two named owners does not delete the other file's service
- [ ] Collision on `service("api")` from two partials errors with the other owner name


Made with [Cursor](https://cursor.com)