### PR TITLE
fix: detect the Railway CLI on Windows in assertMinimumIacCliVersion

### DIFF
--- a/src/iac/cli-version.ts
+++ b/src/iac/cli-version.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
 import process from "node:process";
 import { MINIMUM_IAC_CLI_MESSAGE } from "./compatibility.js";
 
@@ -8,10 +8,7 @@ export function assertMinimumIacCliVersion(): void {
   const executable = process.env._ || "railway";
   let output = "";
   try {
-    output = execFileSync(executable, ["--version"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    output = readCliVersionOutput(executable);
   } catch {
     throw new Error(MINIMUM_IAC_CLI_MESSAGE);
   }
@@ -19,6 +16,24 @@ export function assertMinimumIacCliVersion(): void {
   const version = output.match(/\b(\d+)\.(\d+)\.(\d+)\b/);
   if (!version || compareVersions(version.slice(1).map(Number), [5, 42, 1]) < 0) {
     throw new Error(MINIMUM_IAC_CLI_MESSAGE);
+  }
+}
+
+function readCliVersionOutput(executable: string): string {
+  const options: ExecFileSyncOptionsWithStringEncoding = {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  };
+
+  try {
+    return execFileSync(executable, ["--version"], options);
+  } catch (error) {
+    if (process.platform !== "win32") {
+      throw error;
+    }
+
+    const command = executable.includes(" ") ? `"${executable}"` : executable;
+    return execFileSync(command, ["--version"], { ...options, shell: true });
   }
 }
 


### PR DESCRIPTION
The IaC CLI version check resolved the CLI executable from `process.env._`, a POSIX shell convention that PowerShell and cmd never set, so on Windows the lookup always fell back to the bare "railway" command. npm installs the CLI as a `.cmd`/`.ps1` shim, which execFileSync cannot spawn without a shell, so every evaluation on Windows threw the misleading "requires Railway CLI 5.42.1 or newer" error even when the latest CLI was installed
- and upgrading, as the message suggests, changes nothing.

Retry the version probe through the shell on win32 only, so PATH/PATHEXT resolution finds the npm shim, quoting the command in case a resolved path contains spaces (e.g. under "C:\Program Files"). POSIX platforms rethrow immediately and keep their existing behaviour unchanged.

Verified on Windows 11 (PowerShell, npm-installed CLI 5.45.10): `railway config plan` failed with the version error before the patch and evaluates the IaC file correctly after it. Typecheck and the full vitest suite pass.